### PR TITLE
PRDT-59 and 58: DELETE for facilities, geozones, activities; other fixes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# they will be requested for review when someone opens a pull request.
+*       @marklise @cameronpettit @meredithom @Christopher-walsh22 @davidclaveau

--- a/src/app/inventory/activity/activity-details/activity-details.component.html
+++ b/src/app/inventory/activity/activity-details/activity-details.component.html
@@ -116,7 +116,7 @@
   <div class="row">
     <div class="col-md-6">
       <h4 class="mb-3">Geospatial Details</h4>
-      <div *ngIf="activity?.protectedArea; else noGeozone">
+      <div *ngIf="activity?.geozone; else noGeozone">
         <div class="mb-2">
           <div class="row">
             <div class="col-auto">

--- a/src/app/inventory/activity/activity-details/activity-details.component.ts
+++ b/src/app/inventory/activity/activity-details/activity-details.component.ts
@@ -129,44 +129,4 @@ export class ActivityDetailsComponent {
       ], { padding: 75 });
     }
   }
-
-  async initiateDelete() {
-    console.log('Delete action initiated for activity:', this.activity);
-    await this.displayConfirmationModal()
-  }
-
-  async displayConfirmationModal() {
-    const details: ModalRowSpec[] = [
-      { label: 'Activity to delete', value: this.activity?.displayName },
-    ];
-
-    // Show the modal with the confirmation details.
-    const modalRef = this.modalService.show(ConfirmationModalComponent, {
-      initialState: {
-        title: 'Confirm Delete Activity',
-        details,
-        confirmText: 'Confirm',
-        cancelText: 'Cancel',
-        confirmClass: 'btn btn-primary',
-        cancelClass: 'btn btn-outline-secondary'
-      }
-    });
-
-    // Listen for confirmation and cancellation events from the modal.
-    const modalContent = modalRef.content as ConfirmationModalComponent;
-    modalContent.confirmButton.subscribe(async () => {
-      const collectionId = this.activity?.pk.split('::')[1];
-      const activityType = this.activity?.sk.split('::')[0];
-      const activityId = this.activity?.sk.split('::')[1];
-      const res = await this.activityService.deleteActivity(collectionId, activityType, activityId)
-      modalRef.hide();
-      if (res) {
-        console.log('Activity deleted successfully:', res);
-        this.router.navigate(['/']);
-      }
-    });
-    modalContent.cancelButton.subscribe(() => {
-      modalRef.hide();
-    });
-  }
 }

--- a/src/app/inventory/create-inventory/facility-create/facility-create.component.ts
+++ b/src/app/inventory/create-inventory/facility-create/facility-create.component.ts
@@ -30,12 +30,22 @@ export class FacilityCreateComponent {
   }
 
   async submit() {
-    const collectionId = this.facility?.fcCollectionId;
-    const facilityType = this.facility?.facilityType;
-    const facilityId = this.facility?.facilityId;
+    const collectionId = this.facilityForm.get('fcCollectionId').value || this.facility?.fcCollectionId;
+    const facilityType = this.facilityForm.get('facilityType').value || this.facility?.facilityType;
+
+    if (!collectionId || !facilityType) {
+      console.error('Missing required collection ID or facility type');
+      return;
+    }
+
     const props = this.formatFormForSubmission();
-    const res = await this.facilityService.updateFacility(collectionId, facilityType, facilityId, props);
-    this.navigateToFacility(collectionId, facilityType, facilityId);
+    
+    const res = await this.facilityService.createFacility(collectionId, facilityType, props);
+
+    const facilityId = res[0]?.data?.facilityId;
+    if (facilityId) {
+      this.navigateToFacility(collectionId, facilityType, facilityId);
+    }
   }
 
   formatFormForSubmission() {
@@ -55,7 +65,7 @@ export class FacilityCreateComponent {
         coordinates: [location.longitude, location.latitude]
       };
     };
-    delete props['fcCollectionId']; // Remove gzCollectionId from the props
+    delete props['fcCollectionId']; // Remove fcCollectionId from the props
     delete props['meta']; // Remove meta fields from the props
     return props;
   }

--- a/src/app/inventory/facility/facility-details/facility-details.component.html
+++ b/src/app/inventory/facility/facility-details/facility-details.component.html
@@ -70,6 +70,10 @@
       </div>
       <h5 class="mt-3">Description</h5>
       <p>{{facility?.description || 'No description available.'}}</p>
+      <h5 class="mt-3">Search Terms</h5>
+      <p>{{facility?.searchTerms || 'No search terms available.'}}</p>
+      <h5 class="mt-3">Admin Notes</h5>
+      <p>{{facility?.adminNotes || 'No adminNotes available.'}}</p>
     </div>
     <div class="col-md-6">
       <h4 class="mb-3">Images</h4>

--- a/src/app/inventory/facility/facility-form/facility-form.component.ts
+++ b/src/app/inventory/facility/facility-form/facility-form.component.ts
@@ -193,6 +193,12 @@ export class FacilityFormComponent implements OnInit, AfterViewChecked {
       coordinates: [location.longitude, location.latitude],
       options: this.markerOptions
     }]);
+
+    // This items might get skipped but are required in form submission,
+    // mark as dirty to ensure they are included.
+    this.form.get('timezone').markAsDirty();
+    this.form.get('minMapZoom').markAsDirty();
+    this.form.get('maxMapZoom').markAsDirty();
     this.cdr.detectChanges();
   }
 
@@ -214,7 +220,7 @@ export class FacilityFormComponent implements OnInit, AfterViewChecked {
     });
   }
 
-  updateFacilitySubTypeOptions() {
+  updateFacilitySubTypeOptions() {    
     const type = this.form.get('facilityType')?.value;
     this.facilitySubtypes = Object.entries(Constants.facilityTypes?.[type]?.subTypes || {}).map(([key, value]) => value);
   }

--- a/src/app/inventory/facility/facility.component.html
+++ b/src/app/inventory/facility/facility.component.html
@@ -37,15 +37,24 @@
           </div>
         </button>
         <button
-          class="btn btn-light"
-          disabled
+        class="btn btn-danger"
+        (click)="onDelete()"
         >
-          <div
-            class="badge bg-light text-dark border d-flex justify-content-between align-items-center rounded-pill px-3"
-          >
-            <h5 class="mb-0">v{{data?.version || '?'}}</h5>
-          </div>
-        </button>
+        <div class="col-auto">
+          <i class="fa-solid fa-trash-can me-1"></i>
+          Delete
+        </div>
+      </button>
+      <button
+        class="btn btn-light"
+        disabled
+      >
+        <div
+          class="badge bg-light text-dark border d-flex justify-content-between align-items-center rounded-pill px-3"
+        >
+          <h5 class="mb-0">v{{data?.version || '?'}}</h5>
+        </div>
+      </button>
       </div>
     </div>
   </div>

--- a/src/app/inventory/facility/facility.component.spec.ts
+++ b/src/app/inventory/facility/facility.component.spec.ts
@@ -1,7 +1,11 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { FacilityComponent } from './facility.component';
+import { ConfigService } from '../../services/config.service';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideRouter } from '@angular/router';
+import { provideToastr } from 'ngx-toastr';
 
 describe('FacilityComponent', () => {
   let component: FacilityComponent;
@@ -11,7 +15,11 @@ describe('FacilityComponent', () => {
     await TestBed.configureTestingModule({
       imports: [FacilityComponent],
       providers: [
-        provideRouter([])
+        ConfigService,
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        provideRouter([]),
+        provideToastr()
       ]
     })
     .compileComponents();

--- a/src/app/inventory/facility/facility.component.ts
+++ b/src/app/inventory/facility/facility.component.ts
@@ -2,12 +2,17 @@ import { CommonModule } from '@angular/common';
 import { ChangeDetectorRef, Component } from '@angular/core';
 import { ActivatedRoute, Router, RouterOutlet } from '@angular/router';
 import { Constants } from '../../app.constants';
+import { ModalRowSpec } from '../../shared/components/search-terms/search-terms.component';
+import { ConfirmationModalComponent } from '../../shared/components/confirmation-modal/confirmation-modal.component';
+import { BsModalService } from 'ngx-bootstrap/modal';
+import { FacilityService } from '../../services/facility.service';
 
 @Component({
   selector: 'app-facility',
   imports: [RouterOutlet, CommonModule],
   templateUrl: './facility.component.html',
-  styleUrl: './facility.component.scss'
+  styleUrl: './facility.component.scss',
+  providers: [BsModalService],
 })
 export class FacilityComponent {
   public data;
@@ -15,7 +20,9 @@ export class FacilityComponent {
   constructor(
     protected route: ActivatedRoute,
     protected router: Router,
-    protected cdr: ChangeDetectorRef
+    protected cdr: ChangeDetectorRef,
+    private facilityService: FacilityService,
+    private modalService: BsModalService,
   ) {
     this.route.data.subscribe((data) => {
       if (data?.['facility']) {
@@ -38,6 +45,48 @@ export class FacilityComponent {
       this.router.navigate([`/inventory/facility/${this.data.fcCollectionId}/${this.data.facilityType}/${this.data.facilityId}/edit`]);
     }
     this.cdr.detectChanges();
+  }
+
+  onDelete() {
+    const fcCollectionId = this.data?.fcCollectionId;
+    const facilityType = this.data?.facilityType;
+    const facilityId = this.data?.facilityId;
+
+    this.displayConfirmationModal(fcCollectionId, facilityType, facilityId);
+  }
+
+  // This sends the submitted form data object to the modal for confirmation, where
+  // it constructs a confirmation modal with the details of the protected area and its status.
+  displayConfirmationModal(fcCollectionId, facilityType, facilityId) {
+    const details: ModalRowSpec[] = [
+      { label: 'Facility Name', value: this.data?.displayName },
+      { label: 'Facility Collection ID', value: fcCollectionId },
+      { label: 'Facility Type', value: this.getFacilityTypeOption()?.display },
+      { label: 'Facility ID', value: facilityId }
+    ];
+
+    // Show the modal with the confirmation details.
+    const modalRef = this.modalService.show(ConfirmationModalComponent, {
+      initialState: {
+        title: 'Confirm Delete',
+        details,
+        confirmText: 'Delete',
+        cancelText: 'Cancel',
+        confirmClass: 'btn btn-danger',
+        cancelClass: 'btn btn-outline-secondary'
+      }
+    });
+
+    // Listen for confirmation and cancellation events from the modal.
+    const modalContent = modalRef.content as ConfirmationModalComponent;
+    modalContent.confirmButton.subscribe(() => {
+      this.facilityService.deleteFacility(fcCollectionId, facilityType, facilityId)
+      modalRef.hide();
+      this.router.navigate(['/inventory']);
+    });
+    modalContent.cancelButton.subscribe(() => {
+      modalRef.hide();
+    });
   }
 
 }

--- a/src/app/inventory/geozone/geozone-details/geozone-details.component.spec.ts
+++ b/src/app/inventory/geozone/geozone-details/geozone-details.component.spec.ts
@@ -1,7 +1,11 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { GeozoneDetailsComponent } from './geozone-details.component';
+import { ConfigService } from '../../../services/config.service';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideRouter } from '@angular/router';
+import { provideToastr } from 'ngx-toastr';
 
 describe('GeozoneDetailsComponent', () => {
   let component: GeozoneDetailsComponent;
@@ -10,7 +14,13 @@ describe('GeozoneDetailsComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [GeozoneDetailsComponent],
-      providers: [provideRouter([])]
+      providers: [
+        ConfigService,
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        provideRouter([]),
+        provideToastr()
+      ]
     })
     .compileComponents();
 

--- a/src/app/inventory/geozone/geozone-details/geozone-details.component.ts
+++ b/src/app/inventory/geozone/geozone-details/geozone-details.component.ts
@@ -3,15 +3,21 @@ import { AfterViewInit, ChangeDetectorRef, Component, Input, signal, ViewChild, 
 import { MapComponent } from '../../../map/map.component';
 import { GeozoneEditComponent } from '../geozone-edit/geozone-edit.component';
 import { ActivatedRoute, Router } from '@angular/router';
+import { ModalRowSpec } from '../../../shared/components/search-terms/search-terms.component';
+import { ConfirmationModalComponent } from '../../../shared/components/confirmation-modal/confirmation-modal.component';
+import { GeozoneService } from '../../../services/geozone.service';
+import { BsModalService } from 'ngx-bootstrap/modal';
 
 @Component({
   selector: 'app-geozone-details',
   imports: [CommonModule, UpperCasePipe, DatePipe, MapComponent],
   templateUrl: './geozone-details.component.html',
-  styleUrl: './geozone-details.component.scss'
+  styleUrl: './geozone-details.component.scss',
+  providers: [BsModalService]
 })
 export class GeozoneDetailsComponent implements AfterViewInit {
   @ViewChild('mapComponent') mapComponent!: MapComponent;
+
   public geozone;
   public _markers: WritableSignal<any[]> = signal([]);
   public _envelope: WritableSignal<any[]> = signal([]);
@@ -26,7 +32,9 @@ export class GeozoneDetailsComponent implements AfterViewInit {
   constructor(
     protected router: Router,
     protected cdr: ChangeDetectorRef,
-    protected route: ActivatedRoute
+    protected route: ActivatedRoute,
+    protected geozoneService: GeozoneService,
+    protected modalService: BsModalService
   ) {
     if (this.route.snapshot.data['geozone']) {
       this.geozone = this.route.snapshot.data['geozone'];
@@ -84,6 +92,45 @@ export class GeozoneDetailsComponent implements AfterViewInit {
       ], { padding: 75 });
     }
   }
+
+  async initiateDelete() {
+      console.log('Delete action initiated for geozone:', this.geozone);
+      await this.displayConfirmationModal()
+    }
+  
+    async displayConfirmationModal() {
+      const details: ModalRowSpec[] = [
+        { label: 'Geozone to delete', value: this.geozone?.displayName },
+      ];
+  
+      // Show the modal with the confirmation details.
+      const modalRef = this.modalService.show(ConfirmationModalComponent, {
+        initialState: {
+          title: 'Confirm Delete Geozone',
+          details,
+          confirmText: 'Confirm',
+          cancelText: 'Cancel',
+          confirmClass: 'btn btn-primary',
+          cancelClass: 'btn btn-outline-secondary'
+        }
+      });
+  
+      // Listen for confirmation and cancellation events from the modal.
+      const modalContent = modalRef.content as ConfirmationModalComponent;
+      modalContent.confirmButton.subscribe(async () => {
+        const collectionId = this.geozone?.pk.split('::')[1];
+        const geozoneId = this.geozone?.sk;
+        const res = await this.geozoneService.deleteGeozone(collectionId, geozoneId)
+        modalRef.hide();
+        if (res) {
+          console.log('Geozone deleted successfully:', res);
+          this.router.navigate(['/']);
+        }
+      });
+      modalContent.cancelButton.subscribe(() => {
+        modalRef.hide();
+      });
+    }
 
 
 }

--- a/src/app/inventory/geozone/geozone.component.html
+++ b/src/app/inventory/geozone/geozone.component.html
@@ -28,15 +28,24 @@
           </div>
         </button>
         <button
-          class="btn btn-light"
-          disabled
+        class="btn btn-danger"
+        (click)="onDelete()"
         >
-          <div
-            class="badge bg-light text-dark border d-flex justify-content-between align-items-center rounded-pill px-3"
-          >
-            <h5 class="mb-0">v{{data?.version || '?'}}</h5>
-          </div>
-        </button>
+        <div class="col-auto">
+          <i class="fa-solid fa-trash-can me-1"></i>
+          Delete
+        </div>
+      </button>
+      <button
+        class="btn btn-light"
+        disabled
+      >
+        <div
+          class="badge bg-light text-dark border d-flex justify-content-between align-items-center rounded-pill px-3"
+        >
+          <h5 class="mb-0">v{{data?.version || '?'}}</h5>
+        </div>
+      </button>
       </div>
     </div>
   </div>

--- a/src/app/inventory/geozone/geozone.component.spec.ts
+++ b/src/app/inventory/geozone/geozone.component.spec.ts
@@ -1,9 +1,11 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { GeozoneComponent } from './geozone.component';
+import { ConfigService } from '../../services/config.service';
 import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideRouter } from '@angular/router';
+import { provideToastr } from 'ngx-toastr';
 
 describe('GeozoneComponent', () => {
   let component: GeozoneComponent;
@@ -12,7 +14,13 @@ describe('GeozoneComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [GeozoneComponent],
-      providers: [provideHttpClient(), provideHttpClientTesting(), provideRouter([])]
+      providers: [
+        ConfigService,
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        provideRouter([]),
+        provideToastr()
+      ]
     })
     .compileComponents();
 

--- a/src/app/services/facility.service.ts
+++ b/src/app/services/facility.service.ts
@@ -56,7 +56,7 @@ export class FacilityService {
       this.dataService.setItemValue(Constants.dataIds.FACILITY_RESULT, res);
       this.loadingService.removeFromFetchList(Constants.dataIds.FACILITY_RESULT);
       this.toastService.addMessage(
-        `Facility: ${res.name} created.`,
+        `Facility: ${res[0]?.data?.displayName} created.`,
         '',
         ToastTypes.SUCCESS
       );
@@ -95,4 +95,26 @@ export class FacilityService {
     }
   }
 
+  async deleteFacility(fcCollectionId, facilityType, facilityId) {
+    try {
+      this.loadingService.addToFetchList(Constants.dataIds.FACILITY_RESULT);
+      const res = (await lastValueFrom(this.apiService.delete(`facilities/${fcCollectionId}/${facilityType}/${facilityId}`)))['data'];
+      this.dataService.setItemValue(Constants.dataIds.FACILITY_RESULT, res);
+      this.loadingService.removeFromFetchList(Constants.dataIds.FACILITY_RESULT);
+      this.toastService.addMessage(
+        `Facility successfully deleted.`,
+        '',
+        ToastTypes.SUCCESS
+      );
+      return res;
+    } catch (error) {
+      this.loadingService.removeFromFetchList(Constants.dataIds.FACILITY_RESULT);
+      this.loggerService.error(error);
+      this.toastService.addMessage(
+        `${error}`,
+        `Facility failed to delete`,
+        ToastTypes.ERROR
+      );
+    }
+  }
 }

--- a/src/app/services/geozone.service.ts
+++ b/src/app/services/geozone.service.ts
@@ -57,7 +57,7 @@ export class GeozoneService {
       this.dataService.setItemValue(Constants.dataIds.GEOZONE_RESULT, res);
       this.loadingService.removeFromFetchList(Constants.dataIds.GEOZONE_RESULT);
       this.toastService.addMessage(
-        `Geozone: ${res.name} created.`,
+        `Geozone: ${res[0]?.data?.displayName} created.`,
         '',
         ToastTypes.SUCCESS
       );
@@ -93,6 +93,29 @@ export class GeozoneService {
       );
       this.loadingService.removeFromFetchList(Constants.dataIds.GEOZONE_RESULT);
       this.loggerService.error(error);
+    }
+  }
+
+  async deleteGeozone(gzCollectionId, geozoneId) {
+    try {
+      this.loadingService.addToFetchList(Constants.dataIds.GEOZONE_RESULT);
+      const res = (await lastValueFrom(this.apiService.delete(`geozones/${gzCollectionId}/${geozoneId}`)))['data'];
+      this.dataService.setItemValue(Constants.dataIds.GEOZONE_RESULT, res);
+      this.loadingService.removeFromFetchList(Constants.dataIds.GEOZONE_RESULT);
+      this.toastService.addMessage(
+        `Geozone successfully deleted.`,
+        '',
+        ToastTypes.SUCCESS
+      );
+      return res;
+    } catch (error) {
+      this.loadingService.removeFromFetchList(Constants.dataIds.GEOZONE_RESULT);
+      this.loggerService.error(error);
+      this.toastService.addMessage(
+        `${error}`,
+        `Geozone failed to delete`,
+        ToastTypes.ERROR
+      );
     }
   }
 }


### PR DESCRIPTION
### Ticket:
PRDT-59, PRDT-58

### Ticket URL:
#59, #58 

### Description:
- Created `.github/CODEOWNERS` to define default code reviewers for pull requests

- Activities
  - Fixed template bug: Changed `activity?.protectedArea` to `activity?.geozone` in the activity details template
  - Removed incorrect `delete` functionality from the `ActivityDetailsComponent`

- Facilities
  - Fixed facility creation: Updated `facility-create.component.ts` to properly call `createFacility()` instead of `updateFacility()`
  - Added "Search Terms" and "Admin Notes" sections to facility details view
  - Added delete functionality: Implemented delete button and confirmation modal for facilities
  - Fixed form submission for timezone and map zoom
  - Updated test configurations: Added proper providers for facility component tests
  - Fixed success message to use proper display name from response
  - Added `deleteFacility()` method

- Geozones
  - Added delete functionality: Implemented delete confirmation modal and deletion logic for geozones
  - Updated component structure
  - Updated test configurations
  - Added `deleteGeozone()` method with proper error handling and toast notifications
