### PR TITLE
PRDT-206-1: Add Search Suggestions to Inventory

### DIFF
--- a/src/app/inventory/activity/activity-form/activity-form.component.ts
+++ b/src/app/inventory/activity/activity-form/activity-form.component.ts
@@ -118,7 +118,9 @@ export class ActivityFormComponent implements OnInit, AfterViewChecked {
       geozones: new UntypedFormControl(this.activity?.geozones || ''),
       activitySubType: new UntypedFormControl(this.activity?.activitySubType || ''),
       imageUrl: new UntypedFormControl(this.activity?.imageUrl || ''),
-      searchTerms: new UntypedFormControl(this.activity?.searchTerms || ''),
+      searchTerms: new UntypedFormControl(
+        this.activity?.searchTerms?.join(', ') || ''
+      ),
       adminNotes: new UntypedFormControl(this.activity?.adminNotes || '')
     });
 

--- a/src/app/inventory/create-inventory/activity-create/activity-create.component.ts
+++ b/src/app/inventory/create-inventory/activity-create/activity-create.component.ts
@@ -65,9 +65,12 @@ export class ActivityCreateComponent {
     delete props['allFacilities'];
     delete props['allGeozones'];
 
-    // Handle search terms to be a comma-separated string
-    if (this.activityForm.get('searchTerms')?.value) {
-      props['searchTerms'] = this.activityForm.get('searchTerms')?.value?.join(',') || '';
+    // Handle search terms
+    props['searchTerms'] = this.activityForm.get('searchTerms')?.value || [];
+
+    // Convert orcs to integer
+    if (props['orcs']) {
+      props['orcs'] = parseInt(props['orcs'], 10);
     }
 
     // Remove other form values that are not needed for submission

--- a/src/app/inventory/create-inventory/geozone-create/geozone-create.component.ts
+++ b/src/app/inventory/create-inventory/geozone-create/geozone-create.component.ts
@@ -47,6 +47,13 @@ export class GeozoneCreateComponent {
         [mandatoryFields.envelope.northwest.longitude, mandatoryFields.envelope.northwest.latitude],
         [mandatoryFields.envelope.southeast.longitude, mandatoryFields.envelope.southeast.latitude]]
     };
+    // Convert searchTerms from comma-separated string to array
+    if (props?.searchTerms) {
+      props.searchTerms = props.searchTerms
+        .split(',')
+        .map((term: string) => term.trim())
+        .filter((term: string) => term.length > 0);
+    }
     delete props.collectionId; // Remove collectionId from the props
     delete props.enforceZoomVisibility; // Remove enforceZoomVisibility from the props
     delete props.mandatoryFields; // Remove mandatoryFields from the props

--- a/src/app/inventory/facility/facility-form/facility-form.component.ts
+++ b/src/app/inventory/facility/facility-form/facility-form.component.ts
@@ -141,7 +141,7 @@ export class FacilityFormComponent implements OnInit, AfterViewChecked {
         this.facility?.imageUrl || ''
       ),
       searchTerms: new UntypedFormControl(
-        this.facility?.searchTerms || ''
+        this.facility?.searchTerms?.join(', ') || ''
       ),
       adminNotes: new UntypedFormControl(
         this.facility?.adminNotes || ''

--- a/src/app/inventory/geozone/geozone-edit/geozone-edit.component.ts
+++ b/src/app/inventory/geozone/geozone-edit/geozone-edit.component.ts
@@ -59,6 +59,14 @@ export class GeozoneEditComponent {
         ]
       };
     }
+    // Convert searchTerms from comma-separated string to array
+    if (props?.['searchTerms']) {
+      const searchTermsString = props['searchTerms'];
+      props['searchTerms'] = searchTermsString
+        .split(',')
+        .map((term: string) => term.trim())
+        .filter((term: string) => term.length > 0);
+    }
     delete props['collectionId']; // Remove collectionId from the props
     delete props['enforceZoomVisibility']; // Remove enforceZoomVisibility from the props
     delete props['mandatoryFields']; // Remove location from the props

--- a/src/app/inventory/geozone/geozone-form/geozone-form.component.ts
+++ b/src/app/inventory/geozone/geozone-form/geozone-form.component.ts
@@ -189,7 +189,7 @@ export class GeozoneFormComponent implements OnInit, AfterViewInit {
         this.geozone?.imageUrl || ''
       ),
       searchTerms: new UntypedFormControl(
-        this.geozone?.searchTerms || ''
+        this.geozone?.searchTerms?.join(', ') || ''
       ),
       adminNotes: new UntypedFormControl(
         this.geozone?.adminNotes || ''
@@ -319,5 +319,17 @@ export class GeozoneFormComponent implements OnInit, AfterViewInit {
         this._envelopeMarkers()[0].coordinates[0]
       ], { padding: 75 });
     }
+  }
+
+  /**
+   * Converts the comma-separated searchTerms string to an array
+   * Trims whitespace and filters out empty strings
+   */
+  getSearchTermsArray(): string[] {
+    const searchTermsString = this.form.get('searchTerms')?.value || '';
+    return searchTermsString
+      .split(',')
+      .map((term: string) => term.trim())
+      .filter((term: string) => term.length > 0);
   }
 }

--- a/src/app/inventory/inventory-search/inventory-search.component.html
+++ b/src/app/inventory/inventory-search/inventory-search.component.html
@@ -21,6 +21,8 @@
             [loadWhile]="loadingService?.loading()"
             aria-label="Search for protected areas, facilities, activities, or other data"
             (keyup.enter)="search()"
+            (input)="onSearchInput($event)"
+            (blur)="hideSuggestions()"
           >
             <div ngdsInputAppend>
               <button
@@ -49,6 +51,27 @@
               </button>
             </div>
           </ngds-text-input>
+
+          <!-- Autocomplete Suggestions Dropdown -->
+          <div 
+            *ngIf="showSuggestions && suggestions.length > 0" 
+            class="suggestions-dropdown border rounded-3 mt-1 bg-white shadow-sm"
+            style="max-height: 300px; overflow-y: auto; z-index: 1000;"
+          >
+            <div
+              *ngFor="let suggestion of suggestions"
+              class="suggestion-item p-2 border-bottom"
+              style="cursor: pointer;"
+              (mousedown)="selectSuggestion(suggestion)"
+            >
+              <div class="d-flex align-items-center">
+                <i class="fa fa-search me-2 text-muted"></i>
+                <div class="flex-grow-1">
+                  <div class="fw-bold">{{ suggestion.text }}</div>
+                </div>
+              </div>
+            </div>
+          </div>
 
           <div *ngIf="searchFiltersOpen">
             <div class="border rounded-3 my-1 p-2 text-center">

--- a/src/app/inventory/protected-area/protected-area-edit/protected-area-edit.component.ts
+++ b/src/app/inventory/protected-area/protected-area-edit/protected-area-edit.component.ts
@@ -60,7 +60,9 @@ export class ProtectedAreaEditComponent implements AfterViewChecked, OnDestroy {
       protectedAreaOrcs: new UntypedFormControl(this.protectedArea?.orcs),
       protectedAreaIsVisible: new UntypedFormControl(false),
       protectedAreaAdminNotes: new UntypedFormControl(this.protectedArea?.adminNotes || ''),
-      protectedAreaSearchTerms: new UntypedFormControl(this.searchTerms),
+      protectedAreaSearchTerms: new UntypedFormControl(
+        this.protectedArea?.searchTerms?.join(', ') || ''
+      ),
     });
   }
 

--- a/src/app/sales/sales.component.ts
+++ b/src/app/sales/sales.component.ts
@@ -146,8 +146,6 @@ export class SalesComponent implements OnInit, OnDestroy {
       this.apiService.get('bookings/admin', queryParams)
     );
 
-    console.log('res2 >>>', res);
-
     return res['data'] as SearchResponse;
   }
 

--- a/src/app/services/search.service.ts
+++ b/src/app/services/search.service.ts
@@ -55,7 +55,32 @@ export class SearchService {
     }
   }
 
-  getDocument
+  /**
+   * Performs an autocomplete/suggest search for typeahead functionality.
+   * @param query The text to get suggestions for
+   * @param options Additional options like field, size, fuzziness, and filters
+   * @returns Array of suggestion objects with text and source data
+   */
+  async getSuggestions(query: string, options: any = {}) {
+
+    const body = {
+      text: query,
+      suggest: true,
+      suggestField: options.field || 'searchTerms.suggest',
+      suggestSize: options.size || 10,
+      fuzzy: options.fuzzy || true,
+      fuzziness: options.fuzziness || 'AUTO',
+      ...options.filters || {} // Spread filter fields at top level
+    };
+
+    try {
+      const res: any[] = (await lastValueFrom(this.apiService.post(`search`, body)))['data'];
+      return res; // Returns array of suggestion objects
+    } catch (error) {
+      this.loggerService.error(error);
+      return [];
+    }
+  }
 
   clearSearchResults() {
     this.dataService.setItemValue(Constants.dataIds.SEARCH_RESULTS, []);

--- a/src/app/shared/components/search-terms/search-terms.component.ts
+++ b/src/app/shared/components/search-terms/search-terms.component.ts
@@ -26,19 +26,29 @@ export class SearchTermsComponent {
 
   public utils = new Utils();
 
+  // Convert comma-separated string to array
+  getSearchTermsArray(input: string): string[] {
+    if (!input) return [];
+    console.log('Search term input', input);
+    return input
+      .replace(/\n/g, '')
+      .split(',')
+      .map(term => term.trim())
+      .filter(term => term.length > 0);
+  }
+
   // Add search terms
   onSearchTermAdd() {
     this.searchTermExists = false;
     this.searchTermSet = this.searchTermSet?.trim();
-    this.searchTermSet = this.searchTermSet?.replace(/\n/g, "");
 
     if (this.searchTermSet == '' || this.searchTermSet == null) return;
-    const strings = this.searchTermSet?.split(',');
+    
+    const strings = this.getSearchTermsArray(this.searchTermSet);
 
     if (strings.length > 1) {
       let duplicate = false;
       strings.forEach((string) => {
-        string = string.trim();
         if (string && !this.searchTerms.includes(string)) {
           this.searchTerms.push(string);
         } else if (string) {


### PR DESCRIPTION

#PRDT-206

### Ticket URL:

[#206](https://github.com/bcgov/reserve-rec-api/issues/206)

### Description:

Adding suggestions:
- Added autocomplete functionality to inventory search with real-time suggestions as users type
- Implemented new `getSuggestions` method in search service to query backend for typeahead results
- Added autocomplete dropdown UI in search

Change to saving `searchTerms`:
- Standardized search term storage format to be arrays
- Updated all form components (Activity, Facility, Geozone, Protected Area) to convert between array and string formats
- Added helper methods for parsing comma-separated search terms with trimming and empty string filtering

Bugfix:
- Fixed ORCS value conversion to integer on activity creation