### PR TITLE
Adding domain id and name as SSM exports

### DIFF
--- a/lib/distribution-stack/distribution-stack.js
+++ b/lib/distribution-stack/distribution-stack.js
@@ -204,6 +204,13 @@ class DistributionStack extends BaseStack {
       logBucket: this.logBucket,
       logIncludesCookies: false,
     });
+
+    // Export References
+
+    this.exportReference('distributionId', this.adminDistribution.distributionId, `ID of the Admin CloudFront Distribution in ${this.stackId}`);
+
+    this.exportReference('distributionDomainName', this.adminDistribution.domainName, `Domain name of the Admin CloudFront Distribution in ${this.stackId}`);
+
   }
 }
 


### PR DESCRIPTION
Similar to https://github.com/bcgov/reserve-rec-public/pull/360, Admin FE does not currently export domain ID or name to Parameter Store - they are needed as an import in some cases.