### PR TITLE
fix: use bcparks_ prefix for collectionId in daily passes report

### DIFF
--- a/src/app/reports/daily-passes/daily-passes-report.component.html
+++ b/src/app/reports/daily-passes/daily-passes-report.component.html
@@ -23,7 +23,7 @@
             (ngModelChange)="onCollectionIdChange()"
           >
             <option value="">Select a park...</option>
-            <option *ngFor="let park of protectedAreas" [value]="park.orcs">
+            <option *ngFor="let park of protectedAreas" [value]="'bcparks_' + park.orcs">
               {{ park.displayName }}
             </option>
           </select>

--- a/src/app/reports/daily-passes/daily-passes-report.component.ts
+++ b/src/app/reports/daily-passes/daily-passes-report.component.ts
@@ -217,7 +217,9 @@ export class DailyPassesReportComponent implements OnInit {
   }
 
   private getSelectedParkName(): string {
-    const park = this.protectedAreas.find(p => p.orcs === this.selectedCollectionId);
+    // Extract ORCS from collectionId (e.g., "bcparks_1" -> "1")
+    const orcs = this.selectedCollectionId.replace('bcparks_', '');
+    const park = this.protectedAreas.find(p => p.orcs === orcs);
     if (park) {
       return park.displayName.toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '');
     }


### PR DESCRIPTION
## Summary

- Fixes daily passes report returning no results due to incorrect collectionId format
- The API expects `bcparks_<orcs>` format but the dropdown was only sending the ORCS number

## Changes

- Updated park dropdown to use `bcparks_` prefix for collectionId value
- Updated `getSelectedParkName()` to extract ORCS from the new collectionId format for filename generation

## Related Issue

Issue #106