### PR TITLE
docs: Add sandbox environment documentation to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,36 @@ Run `ng e2e` to execute the end-to-end tests via a platform of your choice. To u
 
 To get more help on the Angular CLI use `ng help` or go check out the [Angular CLI Overview and Command Reference](https://angular.dev/tools/cli) page.
 
+## 🧪 Sandbox Environments
+
+Sandbox environments allow developers to deploy isolated personal environments for testing.
+
+### Quick Start
+
+```bash
+# 1. Setup - copies config from dev
+./scripts/sandbox-setup.sh <your-name>
+
+# 2. Deploy
+SANDBOX_NAME=<your-name> yarn sandbox:deploy
+
+# 3. Teardown when done
+./scripts/sandbox-teardown.sh <your-name>
+```
+
+### Full Stack Deployment
+
+For a complete sandbox environment, you must also deploy `reserve-rec-api` and `reserve-rec-public`. See the [reserve-rec-api README](https://github.com/bcgov/reserve-rec-api#-sandbox-environments) for full instructions.
+
+### Available Scripts
+
+| Script | Description |
+|--------|-------------|
+| `./scripts/sandbox-setup.sh <name> [base-env]` | Copy SSM configs and secrets from base environment |
+| `./scripts/sandbox-teardown.sh <name>` | Destroy CDK stacks and cleanup resources |
+| `yarn sandbox:deploy` | CDK deploy with SANDBOX_NAME env var |
+| `yarn sandbox:destroy` | CDK destroy with SANDBOX_NAME env var |
+
 # Deploying with CDK
 
 The `cdk.json` file tells the CDK Toolkit how to execute your app. The build step is not required when using JavaScript.


### PR DESCRIPTION
## Summary

Adds comprehensive documentation for sandbox environments to the README, including:
- Quick start guide for setting up and tearing down sandboxes
- Available scripts reference table
- Link to full stack deployment instructions in reserve-rec-api
- Instructions for deploying complete sandbox environment across all three repos

This documentation complements the sandbox infrastructure that was recently merged and makes it easier for developers to use personal sandbox environments for testing.