### PR TITLE
PRDT-172: Roles and Permissions

### DIFF
--- a/.github/workflows/analysis.yaml
+++ b/.github/workflows/analysis.yaml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Run Trivy vulnerability scanner in repo mode
-        uses: aquasecurity/trivy-action@0.22.0
+        uses: aquasecurity/trivy-action@0.35.0
         with:
           format: "sarif"
           output: "trivy-results.sarif"

--- a/src/app/admin/feature-flags/feature-flags.component.html
+++ b/src/app/admin/feature-flags/feature-flags.component.html
@@ -16,7 +16,7 @@
     <div *ngIf="flagData?.metadata" class="alert alert-light mb-4">
       <small>
         <strong>Last updated:</strong> {{ flagData?.metadata?.lastUpdated | date:'medium' }}
-        by {{ flagData?.metadata?.updatedByEmail || flagData?.metadata?.updatedBy }}
+        by {{ flagData?.metadata?.updatedByUsername || flagData?.metadata?.updatedBy }}
       </small>
     </div>
 

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -1,6 +1,7 @@
 import { Routes } from '@angular/router';
 import { UserGuard } from './guards/user.guard';
 import { AdminGuard } from './guards/admin.guard';
+import { PermissionsGuard } from './guards/permissions.guard';
 import { GeozoneResolver } from './resolvers/geozone.resolver';
 import { ProtectedAreaResolver } from './resolvers/protected-area.resolver';
 import { FacilityResolver } from './resolvers/facility.resolver';
@@ -32,121 +33,152 @@ export const routes: Routes = [
   },
   {
     path: 'sales',
-    loadComponent: () => import('./sales/sales.component').then(mod => mod.SalesComponent), canActivate: [UserGuard]
+    loadComponent: () => import('./sales/sales.component').then(mod => mod.SalesComponent),
+    canActivate: [UserGuard, PermissionsGuard],
+    data: { requiredPermission: 'limited' },
   },
   {
     path: 'customers',
     loadComponent: () => import('./customers/customers.component').then(mod => mod.CustomersComponent),
-    canActivate: [UserGuard]
-  },
-  {
-    path: 'customers/:id',
-    loadComponent: () => import('./customers/customer-detail/customer-detail.component').then(mod => mod.CustomerDetailComponent),
-    canActivate: [UserGuard]
-  },
-  {
-    path: 'customers/:id/edit',
-    loadComponent: () => import('./customers/customer-edit/customer-edit.component').then(mod => mod.CustomerEditComponent),
-    canActivate: [UserGuard]
+    canActivate: [UserGuard, PermissionsGuard],
+    data: { requiredPermission: 'staff' },
+    children: [
+      {
+        path: ':id',
+        loadComponent: () => import('./customers/customer-detail/customer-detail.component').then(mod => mod.CustomerDetailComponent),
+        canActivate: [UserGuard, PermissionsGuard],
+        data: { requiredPermission: 'staff' },
+      },
+      {
+        path: ':id/edit',
+        loadComponent: () => import('./customers/customer-edit/customer-edit.component').then(mod => mod.CustomerEditComponent),
+        canActivate: [UserGuard, PermissionsGuard],
+        data: { requiredPermission: 'staff' },
+      }
+    ]
   },
   // Inventory
   {
     path: 'inventory',
     loadComponent: () => import('./inventory/inventory.component').then(mod => mod.InventoryComponent),
-    canActivate: [UserGuard]
+    canActivate: [UserGuard, PermissionsGuard],
+    data: { requiredPermission: 'limited' },
   },
   {
     path: 'inventory/create',
     loadComponent: () => import('./inventory/create-inventory/create-inventory.component').then(mod => mod.CreateInventoryComponent),
-    canActivate: [UserGuard],
+    canActivate: [UserGuard, PermissionsGuard],
+    data: { requiredPermission: 'superadmin' },
     children: [
       {
         path: 'geozone',
-        loadComponent: () => import('./inventory/create-inventory/geozone-create/geozone-create.component').then(mod => mod.GeozoneCreateComponent)
+        loadComponent: () => import('./inventory/create-inventory/geozone-create/geozone-create.component').then(mod => mod.GeozoneCreateComponent),
+        canActivate: [UserGuard, PermissionsGuard],
+        data: { requiredPermission: 'superadmin' },
       },
       {
         path: 'facility',
-        loadComponent: () => import('./inventory/create-inventory/facility-create/facility-create.component').then(mod => mod.FacilityCreateComponent)
+        loadComponent: () => import('./inventory/create-inventory/facility-create/facility-create.component').then(mod => mod.FacilityCreateComponent),
+        canActivate: [UserGuard, PermissionsGuard],
+        data: { requiredPermission: 'superadmin' },
       },
       {
         path: 'activity',
         loadComponent: () => import('./inventory/create-inventory/activity-create/activity-create.component').then(mod => mod.ActivityCreateComponent),
-        // resolve: { protectedAreas: ProtectedAreasResolver }
+        canActivate: [UserGuard, PermissionsGuard],
+        data: { requiredPermission: 'superadmin' },
       },
       {
         path: 'product',
-        loadComponent: () => import('./inventory/create-inventory/product-create/product-create.component').then(mod => mod.ProductCreateComponent)
+        loadComponent: () => import('./inventory/create-inventory/product-create/product-create.component').then(mod => mod.ProductCreateComponent),
+        canActivate: [UserGuard, PermissionsGuard],
+        data: { requiredPermission: 'superadmin' },
       },
       {
         path: 'policy',
-        loadComponent: () => import('./inventory/create-inventory/policy-create/policy-create.component').then(mod => mod.PolicyCreateComponent)
+        loadComponent: () => import('./inventory/create-inventory/policy-create/policy-create.component').then(mod => mod.PolicyCreateComponent),
+        canActivate: [UserGuard, PermissionsGuard],
+        data: { requiredPermission: 'superadmin' },
       },
       {
         path: 'relationships',
-        loadComponent: () => import('./inventory/create-inventory/relationship-create/relationship-create.component').then(mod => mod.RelationshipCreateComponent)
+        loadComponent: () => import('./inventory/create-inventory/relationship-create/relationship-create.component').then(mod => mod.RelationshipCreateComponent),
+        canActivate: [UserGuard, PermissionsGuard],
+        data: { requiredPermission: 'superadmin' },
       },
     ],
   },
   {
     path: 'inventory/geozone/:collectionId/:geozoneId',
     loadComponent: () => import('./inventory/geozone/geozone.component').then(mod => mod.GeozoneComponent),
-    canActivate: [UserGuard],
+    canActivate: [UserGuard, PermissionsGuard],
+    data: { requiredPermission: 'limited' },
     resolve: { geozone: GeozoneResolver },
     children: [
       {
         path: '',
         loadComponent: () => import('./inventory/geozone/geozone-details/geozone-details.component').then(mod => mod.GeozoneDetailsComponent),
-        canActivate: [UserGuard],
+        canActivate: [UserGuard, PermissionsGuard],
+        data: { requiredPermission: 'limited' },
       },
       {
         path: 'edit',
         loadComponent: () => import('./inventory/geozone/geozone-edit/geozone-edit.component').then(mod => mod.GeozoneEditComponent),
-        canActivate: [UserGuard],
+        canActivate: [UserGuard, PermissionsGuard],
+        data: { requiredPermission: 'superadmin' },
       }
     ]
   },
   {
     path: 'inventory/facility/:collectionId/:facilityType/:facilityId',
     loadComponent: () => import('./inventory/facility/facility.component').then(mod => mod.FacilityComponent),
-    canActivate: [UserGuard],
+    canActivate: [UserGuard, PermissionsGuard],
+    data: { requiredPermission: 'limited' },
     resolve: { facility: FacilityResolver },
     runGuardsAndResolvers: 'always',
     children: [
       {
         path: '',
         loadComponent: () => import('./inventory/facility/facility-details/facility-details.component').then(mod => mod.FacilityDetailsComponent),
-        canActivate: [UserGuard],
+        canActivate: [UserGuard, PermissionsGuard],
+        data: { requiredPermission: 'limited' }
       },
       {
         path: 'edit',
         loadComponent: () => import('./inventory/facility/facility-edit/facility-edit.component').then(mod => mod.FacilityEditComponent),
-        canActivate: [UserGuard],
+        canActivate: [UserGuard, PermissionsGuard],
+        data: { requiredPermission: 'staff' }
+
       }
     ]
   },
   {
     path: 'inventory/activity/:collectionId/:activityType/:activityId',
     loadComponent: () => import('./inventory/activity/activity.component').then(mod => mod.ActivityComponent),
-    canActivate: [UserGuard],
+    canActivate: [UserGuard, PermissionsGuard],
+    data: { requiredPermission: 'limited' },
     resolve: { activity: ActivityResolver },
     runGuardsAndResolvers: 'always',
     children: [
       {
         path: '',
         loadComponent: () => import('./inventory/activity/activity-details/activity-details.component').then(mod => mod.ActivityDetailsComponent),
-        canActivate: [UserGuard],
+        canActivate: [UserGuard, PermissionsGuard],
+        data: { requiredPermission: 'limited' },
       },
       {
         path: 'edit',
         loadComponent: () => import('./inventory/activity/activity-edit/activity-edit.component').then(mod => mod.ActivityEditComponent),
-        canActivate: [UserGuard],
+        canActivate: [UserGuard, PermissionsGuard],
+        data: { requiredPermission: 'staff' },
       }
     ]
   },
   {
     path: 'inventory/policy/:policyType/:policyId',
     loadComponent: () => import('./inventory/policy/policy.component').then(mod => mod.PolicyComponent),
-    canActivate: [UserGuard],
+    canActivate: [UserGuard, PermissionsGuard],
+    data: { requiredPermission: 'limited' },
     resolve: { policy: policyResolver },
     runGuardsAndResolvers: 'always',
     children: [
@@ -159,7 +191,8 @@ export const routes: Routes = [
         path: ':policyIdVersion',
         loadComponent: () => import('./inventory/policy/policy-details/policy-details.component').then(mod => mod.PolicyDetailsComponent),
         resolve: { policy: policyResolver },
-        canActivate: [UserGuard],
+        canActivate: [UserGuard, PermissionsGuard],
+        data: { requiredPermission: 'limited' },
         children: [
         ]
       }
@@ -168,19 +201,22 @@ export const routes: Routes = [
   {
     path: 'inventory/product/:collectionId/:activityType/:activityId/:productId',
     loadComponent: () => import('./inventory/product/product.component').then(mod => mod.ProductComponent),
-    canActivate: [UserGuard],
+    canActivate: [UserGuard, PermissionsGuard],
+    data: { requiredPermission: 'limited' },
     resolve: { product: ProductResolver },
     runGuardsAndResolvers: 'always',
     children: [
       {
         path: '',
         loadComponent: () => import('./inventory/product/product-details/product-details.component').then(mod => mod.ProductDetailsComponent),
-        canActivate: [UserGuard],
+        canActivate: [UserGuard, PermissionsGuard],
+        data: { requiredPermission: 'limited' },
       },
       {
         path: 'edit',
         loadComponent: () => import('./inventory/product/product-edit/product-edit.component').then(mod => mod.ProductEditComponent),
-        canActivate: [UserGuard],
+        canActivate: [UserGuard, PermissionsGuard],
+        data: { requiredPermission: 'limited' },
       }
     ]
   },
@@ -192,38 +228,39 @@ export const routes: Routes = [
   {
     path: 'reports',
     loadComponent: () => import('./reports/reports.component').then(mod => mod.ReportsComponent),
-    canActivate: [UserGuard]
-  },
+    canActivate: [UserGuard, PermissionsGuard],
+    data: { requiredPermission: 'limited' },
+},
   {
     path: 'reports/daily-passes',
     loadComponent: () => import('./reports/daily-passes/daily-passes-report.component').then(mod => mod.DailyPassesReportComponent),
-    canActivate: [UserGuard]
+    canActivate: [UserGuard, PermissionsGuard],
+    data: { requiredPermission: 'limited' },
   },
   {
     path: 'admin/feature-flags',
     loadComponent: () => import('./admin/feature-flags/feature-flags.component').then(mod => mod.FeatureFlagsComponent),
-    canActivate: [UserGuard, AdminGuard]
+    canActivate: [UserGuard, PermissionsGuard],
+    data: { requiredPermission: 'superadmin' },
   },
   {
     path: 'admin/waiting-room',
     loadComponent: () => import('./admin/waiting-room/waiting-room-admin.component').then(mod => mod.WaitingRoomAdminComponent),
-    canActivate: [UserGuard, AdminGuard]
-  },
-  {
-    path: 'customers',
-    loadComponent: () => import('./customers/customers.component').then(mod => mod.CustomersComponent),
-    canActivate: [UserGuard]
+    canActivate: [UserGuard, PermissionsGuard],
+    data: { requiredPermission: 'superadmin' },
   },
   {
     path: 'inventory/protected-area/:orcs',
     loadComponent: () => import('./inventory/protected-area/protected-area-details/protected-area-details.component').then(mod => mod.ProtectedAreaDetailsComponent),
-    canActivate: [UserGuard],
+    canActivate: [UserGuard, PermissionsGuard],
+    data: { requiredPermission: 'limited' },
     resolve: { protectedArea: ProtectedAreaResolver }
   },
   {
     path: 'inventory/protected-area/:orcs/edit',
     loadComponent: () => import('./inventory/protected-area/protected-area-edit/protected-area-edit.component').then(mod => mod.ProtectedAreaEditComponent),
-    canActivate: [UserGuard],
+    canActivate: [UserGuard, PermissionsGuard],
+    data: { requiredPermission: 'superadmin' },
     resolve: { protectedArea: ProtectedAreaResolver }
   },
 ];

--- a/src/app/guards/admin.guard.ts
+++ b/src/app/guards/admin.guard.ts
@@ -1,20 +1,17 @@
 import { Injectable } from '@angular/core';
-import { CanActivate, Router } from '@angular/router';
-import { AuthService } from '../services/auth.service';
+import { CanActivate, Router, UrlTree } from '@angular/router';
+import { PermissionsService } from '../services/permissions.service';
 
 @Injectable({
   providedIn: 'root',
 })
 export class AdminGuard implements CanActivate {
-  constructor(private authService: AuthService, private router: Router) {}
+  constructor(private permissionsService: PermissionsService, private router: Router) {}
 
-  async canActivate(): Promise<boolean> {
-    const isAdmin = await this.authService.userIsAdmin();
-    if (isAdmin) {
-      return true; // Allow access if user is a superadmin
-    } else {
-      this.router.navigate(['/unauthorized']); // Not a superadmin, redirect to unauthorized
-      return false;
+  canActivate(): boolean | UrlTree {
+    if (this.permissionsService.isSuperAdmin()) {
+      return true;
     }
+    return this.router.parseUrl('/unauthorized');
   }
 }

--- a/src/app/guards/permissions.guard.ts
+++ b/src/app/guards/permissions.guard.ts
@@ -1,0 +1,54 @@
+import { Injectable } from '@angular/core';
+import { ActivatedRouteSnapshot, CanActivate, Router, UrlTree } from '@angular/router';
+import { PermissionsService } from '../services/permissions.service';
+
+/**
+ * Guards routes that require a minimum permission tier.
+ *
+ * Route data options:
+ *   requiredPermission: 'limited' | 'staff'  — minimum tier required
+ *
+ * If the route has a `collectionId` path param the check is scoped to that
+ * specific collection (park). Otherwise the user just needs the tier on any
+ * collection they manage.
+ *
+ * Superadmins always pass.
+ *
+ * Example:
+ *   canActivate: [UserGuard, PermissionsGuard]
+ *   data: { requiredPermission: 'staff' }
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class PermissionsGuard implements CanActivate {
+  constructor(private permissionsService: PermissionsService, private router: Router) {}
+
+  canActivate(route: ActivatedRouteSnapshot): boolean | UrlTree {
+    if (this.permissionsService.isSuperAdmin()) {
+      return true;
+    }
+
+    const required: string | undefined = route.data?.['requiredPermission'];
+    if (!required) {
+      return true;
+    }
+
+    const collectionId = this.resolveParam(route, 'collectionId');
+    return this.permissionsService.hasPermission(required, collectionId ?? undefined)
+      ? true
+      : this.router.parseUrl('/unauthorized');
+  }
+
+  // Walk up the activated route snapshot tree to find a named param
+  private resolveParam(route: ActivatedRouteSnapshot, param: string): string | null {
+    let current: ActivatedRouteSnapshot | null = route;
+    while (current) {
+      if (current.params[param]) {
+        return current.params[param];
+      }
+      current = current.parent;
+    }
+    return null;
+  }
+}

--- a/src/app/guards/user.guard.ts
+++ b/src/app/guards/user.guard.ts
@@ -1,20 +1,18 @@
 import { Injectable } from '@angular/core';
-import { CanActivate, Router } from '@angular/router';
+import { CanActivate, Router, UrlTree } from '@angular/router';
 import { AuthService } from '../services/auth.service';
 
 @Injectable({
   providedIn: 'root',
 })
 export class UserGuard implements CanActivate {
-    constructor(private authService: AuthService, private router: Router) {}
+  constructor(private authService: AuthService, private router: Router) {}
 
-    async canActivate(): Promise<boolean> {
-      const user = await this.authService.getCurrentUser();
-      if (user) {
-        return true; // Allow access if user exists
-      } else {
-        this.router.navigate(['/login']); // No user exists, redirect to login
-        return false;
-      }
+  canActivate(): boolean | UrlTree {
+    // Read from the cached session signal — no Cognito network call on every navigation
+    if (this.authService.session()?.tokens) {
+      return true;
     }
+    return this.router.parseUrl('/login');
   }
+}

--- a/src/app/inventory/activity/activity.component.html
+++ b/src/app/inventory/activity/activity.component.html
@@ -30,7 +30,7 @@
         <button
           class="btn btn-light"
           (click)="navToEdit()"
-          *permissionRequired="'superadmin'"
+          *appPermissionRequired="'superadmin'"
         >
           <div class="col-auto">
             <i class="fa-solid fa-pen-to-square me-1"></i>
@@ -40,7 +40,7 @@
         <button
           class="btn btn-danger"
           (click)="onDelete()"
-          *permissionRequired="'superadmin'"
+          *appPermissionRequired="'superadmin'"
         >
         <div class="col-auto">
           <i class="fa-solid fa-trash-can me-1"></i>

--- a/src/app/inventory/activity/activity.component.html
+++ b/src/app/inventory/activity/activity.component.html
@@ -30,6 +30,7 @@
         <button
           class="btn btn-light"
           (click)="navToEdit()"
+          *permissionRequired="'superadmin'"
         >
           <div class="col-auto">
             <i class="fa-solid fa-pen-to-square me-1"></i>
@@ -37,8 +38,9 @@
           </div>
         </button>
         <button
-        class="btn btn-danger"
-        (click)="onDelete()"
+          class="btn btn-danger"
+          (click)="onDelete()"
+          *permissionRequired="'superadmin'"
         >
         <div class="col-auto">
           <i class="fa-solid fa-trash-can me-1"></i>

--- a/src/app/inventory/activity/activity.component.ts
+++ b/src/app/inventory/activity/activity.component.ts
@@ -7,10 +7,11 @@ import { ConfirmationModalComponent } from '../../shared/components/confirmation
 import { BsModalService } from 'ngx-bootstrap/modal';
 import { ModalRowSpec } from '../../shared/components/search-terms/search-terms.component';
 import { ActivityService } from '../../services/activity.service';
+import { PermissionDirective } from '../../shared/directives/permission.directive';
 
 @Component({
   selector: 'app-activity',
-  imports: [RouterOutlet, CommonModule],
+  imports: [RouterOutlet, CommonModule, PermissionDirective],
   templateUrl: './activity.component.html',
   styleUrl: './activity.component.scss',
   providers: [BsModalService]

--- a/src/app/inventory/create-inventory/product-create/product-create.component.ts
+++ b/src/app/inventory/create-inventory/product-create/product-create.component.ts
@@ -4,6 +4,7 @@ import { ProductService } from '../../../services/product.service';
 import { ActivatedRoute, Router } from '@angular/router';
 import { ProductFormComponent } from '../../product/product-form/product-form.component';
 import { LoadalComponent } from '../../../shared/components/loadal/loadal.component';
+import { ToastService, ToastTypes } from '../../../services/toast.service';
 
 @Component({
   selector: 'app-product-create',
@@ -21,7 +22,8 @@ export class ProductCreateComponent {
     protected productService: ProductService,
     protected router: Router,
     protected cdr: ChangeDetectorRef,
-    protected route: ActivatedRoute
+    protected route: ActivatedRoute,
+    protected toastService: ToastService,
   ) {
     if (this.route.parent?.snapshot.data['product']) {
       this.product = this.route.parent?.snapshot.data['product'];
@@ -51,12 +53,25 @@ export class ProductCreateComponent {
       return;
     }
 
-    const collectionId = this.productForm.get('collectionId').value || this.product?.collectionId;
-    const activityType = this.productForm.get('activityType').value || this.product?.activityType;
-    const activityId = this.productForm.get('activityId').value || this.product?.activityId;
+    const collectionId = this.productForm.get('collectionId').value ?? this.product?.collectionId;
+    const activityType = this.productForm.get('activityType').value ?? this.product?.activityType;
+    const activityId = this.productForm.get('activityId').value ?? this.product?.activityId;
 
     if (!collectionId || !activityType || !activityId) {
       console.error('Missing required collection ID, activity type, and/or activity ID');
+      // Figure out which is missing
+      const missingFields = [];
+      if (!collectionId) missingFields.push('collectionId');
+      if (!activityType) missingFields.push('activityType');
+      if (!activityId) missingFields.push('activityId');
+
+      // Show error to user in the app via toastr
+      this.toastService.addMessage(
+        `${missingFields.join(', ')} ${missingFields.length > 1 ? 'are' : 'is'} required to create a product`,
+        `Product failed to create`,
+        ToastTypes.ERROR
+      );
+
       return;
     }
 

--- a/src/app/inventory/facility/facility-details/facility-details.component.html
+++ b/src/app/inventory/facility/facility-details/facility-details.component.html
@@ -48,7 +48,7 @@
             </div>
           </div>
 
-          <div class="row mt-2" *permissionRequired="'superadmin'">
+          <div class="row mt-2" *appPermissionRequired="'superadmin'">
             <div class="col-12 d-flex align-items-start justify-content-start gap-3">
               <p class="small fw-bold">Admin&nbsp;notes:</p>
               <p class="small">{{ facility?.adminNotes || 'No admin notes provided.' }}</p>

--- a/src/app/inventory/facility/facility-details/facility-details.component.html
+++ b/src/app/inventory/facility/facility-details/facility-details.component.html
@@ -48,7 +48,7 @@
             </div>
           </div>
 
-          <div class="row mt-2">
+          <div class="row mt-2" *permissionRequired="'superadmin'">
             <div class="col-12 d-flex align-items-start justify-content-start gap-3">
               <p class="small fw-bold">Admin&nbsp;notes:</p>
               <p class="small">{{ facility?.adminNotes || 'No admin notes provided.' }}</p>

--- a/src/app/inventory/facility/facility-details/facility-details.component.ts
+++ b/src/app/inventory/facility/facility-details/facility-details.component.ts
@@ -6,10 +6,11 @@ import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 import { Constants } from '../../../app.constants';
 import { ActivityListItemComponent } from '../../activity/activity-list-item/activity-list-item.component';
 import { RelationshipService } from '../../../services/relationship.service';
+import { PermissionDirective } from '../../../shared/directives/permission.directive';
 
 @Component({
   selector: 'app-facility-details',
-  imports: [MapComponent, DatePipe, CommonModule, ActivityListItemComponent ],
+  imports: [MapComponent, DatePipe, CommonModule, ActivityListItemComponent, PermissionDirective ],
   templateUrl: './facility-details.component.html',
   styleUrl: './facility-details.component.scss'
 })

--- a/src/app/inventory/facility/facility-form/facility-form.component.html
+++ b/src/app/inventory/facility/facility-form/facility-form.component.html
@@ -138,7 +138,7 @@
             <div class="col-12 col-lg-6">
               <ngds-text-input class="mb-4"
                 [control]="form.get('adminNotes')"
-                *permissionRequired="'staff'"
+                *appPermissionRequired="'staff'"
                 [label]="'Admin notes'"
                 [multiline]="true"
                 [placeholder]="'Type any admin notes for the facility'">

--- a/src/app/inventory/facility/facility-form/facility-form.component.html
+++ b/src/app/inventory/facility/facility-form/facility-form.component.html
@@ -138,6 +138,7 @@
             <div class="col-12 col-lg-6">
               <ngds-text-input class="mb-4"
                 [control]="form.get('adminNotes')"
+                *permissionRequired="'staff'"
                 [label]="'Admin notes'"
                 [multiline]="true"
                 [placeholder]="'Type any admin notes for the facility'">

--- a/src/app/inventory/facility/facility-form/facility-form.component.ts
+++ b/src/app/inventory/facility/facility-form/facility-form.component.ts
@@ -13,6 +13,7 @@ import { EntityRelationshipSelectorComponent } from '../../../shared/components/
 import { ActivityService } from '../../../services/activity.service';
 import { EntityFormBaseComponent } from '../../../shared/components/entity/entity-base/entity-form-base.component';
 import { NgbTooltip } from '@ng-bootstrap/ng-bootstrap';
+import { PermissionDirective } from '../../../shared/directives/permission.directive';
 
 @Component({
   selector: 'app-facility-form',
@@ -26,6 +27,7 @@ import { NgbTooltip } from '@ng-bootstrap/ng-bootstrap';
     ReactiveFormsModule,
     EntityRelationshipSelectorComponent,
     NgbTooltip,
+    PermissionDirective
   ],
   providers: [],
   templateUrl: './facility-form.component.html',

--- a/src/app/inventory/facility/facility.component.html
+++ b/src/app/inventory/facility/facility.component.html
@@ -36,7 +36,7 @@
         <button
           class="btn btn-outline-danger rounded-1"
           (click)="onDelete()"
-          *permissionRequired="'superadmin'"
+          *appPermissionRequired="'superadmin'"
         >
           <div class="col-auto">
             Delete
@@ -45,7 +45,7 @@
         <button 
           class="btn btn-outline-secondary rounded-1"
           (click)="navToEdit()"
-          *permissionRequired="'staff'"
+          *appPermissionRequired="'staff'"
         >
           <div class="col-auto">
             Edit

--- a/src/app/inventory/facility/facility.component.html
+++ b/src/app/inventory/facility/facility.component.html
@@ -33,12 +33,20 @@
     </div>
     <div class="col-auto mt-3 mt-lg-1 ps-4 pe-4" *ngIf="!isEditing">
       <div class="d-flex justify-content-end align-items-center gap-2">
-        <button class="btn btn-outline-danger rounded-1" (click)="onDelete()">
+        <button
+          class="btn btn-outline-danger rounded-1"
+          (click)="onDelete()"
+          *permissionRequired="'superadmin'"
+        >
           <div class="col-auto">
             Delete
           </div>
         </button>
-        <button class="btn btn-outline-secondary rounded-1" (click)="navToEdit()">
+        <button 
+          class="btn btn-outline-secondary rounded-1"
+          (click)="navToEdit()"
+          *permissionRequired="'staff'"
+        >
           <div class="col-auto">
             Edit
           </div>

--- a/src/app/inventory/facility/facility.component.ts
+++ b/src/app/inventory/facility/facility.component.ts
@@ -6,10 +6,11 @@ import { ModalRowSpec } from '../../shared/components/search-terms/search-terms.
 import { ConfirmationModalComponent } from '../../shared/components/confirmation-modal/confirmation-modal.component';
 import { BsModalService } from 'ngx-bootstrap/modal';
 import { FacilityService } from '../../services/facility.service';
+import { PermissionDirective } from '../../shared/directives/permission.directive';
 
 @Component({
   selector: 'app-facility',
-  imports: [RouterOutlet, CommonModule],
+  imports: [RouterOutlet, CommonModule, PermissionDirective],
   templateUrl: './facility.component.html',
   styleUrl: './facility.component.scss',
   providers: [BsModalService],

--- a/src/app/inventory/inventory.component.html
+++ b/src/app/inventory/inventory.component.html
@@ -5,7 +5,7 @@
       <button 
         class="btn btn-success"
         (click)="createNewInventory()"
-        *permissionRequired="'superadmin'"  
+        *appPermissionRequired="'superadmin'"
       >
         <i class="fa fa-plus"></i>
         Create New Inventory

--- a/src/app/inventory/inventory.component.html
+++ b/src/app/inventory/inventory.component.html
@@ -2,8 +2,13 @@
   <div class="col h-100 d-flex flex-column ">
     <div class="d-flex justify-content-between align-items-center mb-3">
       <h3>Inventory Management</h3>
-      <button class="btn btn-success" (click)="createNewInventory()">
-        <i class="fa fa-plus"></i> Create New Inventory
+      <button 
+        class="btn btn-success"
+        (click)="createNewInventory()"
+        *permissionRequired="'superadmin'"  
+      >
+        <i class="fa fa-plus"></i>
+        Create New Inventory
       </button>
     </div>
     <div class="flex-grow-1">

--- a/src/app/inventory/inventory.component.ts
+++ b/src/app/inventory/inventory.component.ts
@@ -2,10 +2,11 @@ import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { InventorySearchComponent } from './inventory-search/inventory-search.component';
 import { Router } from '@angular/router';
+import { PermissionDirective } from '../shared/directives/permission.directive';
 
 @Component({
   selector: 'app-inventory-component',
-  imports: [InventorySearchComponent, CommonModule],
+  imports: [InventorySearchComponent, CommonModule, PermissionDirective],
   templateUrl: './inventory.component.html',
   styleUrls: ['./inventory.component.scss']
 })

--- a/src/app/inventory/product/product-details/product-details.component.html
+++ b/src/app/inventory/product/product-details/product-details.component.html
@@ -36,7 +36,7 @@
             </div>
           </div>
 
-          <div class="row mt-2" *permissionRequired="'superadmin'">
+          <div class="row mt-2" *appPermissionRequired="'superadmin'">
             <div class="col-12 d-flex align-items-start justify-content-start gap-3">
               <p class="small fw-bold">Admin&nbsp;notes:</p>
               <p class="small">{{ product?.adminNotes || 'No admin notes provided.' }}</p>

--- a/src/app/inventory/product/product-details/product-details.component.html
+++ b/src/app/inventory/product/product-details/product-details.component.html
@@ -36,7 +36,7 @@
             </div>
           </div>
 
-          <div class="row mt-2">
+          <div class="row mt-2" *permissionRequired="'superadmin'">
             <div class="col-12 d-flex align-items-start justify-content-start gap-3">
               <p class="small fw-bold">Admin&nbsp;notes:</p>
               <p class="small">{{ product?.adminNotes || 'No admin notes provided.' }}</p>

--- a/src/app/inventory/product/product-details/product-details.component.ts
+++ b/src/app/inventory/product/product-details/product-details.component.ts
@@ -8,10 +8,11 @@ import { ActivityService } from '../../../services/activity.service';
 import { PolicyService } from '../../../services/policy.service';
 import { ProductService } from '../../../services/product.service';
 import { ProductDateService } from '../../../services/product-date.service';
+import { PermissionDirective } from '../../../shared/directives/permission.directive';
 
 @Component({
   selector: 'app-product-details',
-  imports: [DatePipe, CommonModule, ActivityListItemComponent, PolicyListItemComponent],
+  imports: [DatePipe, CommonModule, ActivityListItemComponent, PolicyListItemComponent, PermissionDirective],
   templateUrl: './product-details.component.html',
   styleUrl: './product-details.component.scss'
 })

--- a/src/app/inventory/product/product-form/product-form.component.html
+++ b/src/app/inventory/product/product-form/product-form.component.html
@@ -102,7 +102,7 @@
             </div>
           </div>
           
-          <div class="row mt-4">
+          <div class="row mt-4" *permissionRequired="'superadmin'">
             <div class="col-12 col-lg-6">
               <ngds-text-input class="mb-4"
                 [control]="form.get('adminNotes')"

--- a/src/app/inventory/product/product-form/product-form.component.html
+++ b/src/app/inventory/product/product-form/product-form.component.html
@@ -102,7 +102,7 @@
             </div>
           </div>
           
-          <div class="row mt-4" *permissionRequired="'superadmin'">
+          <div class="row mt-4" *appPermissionRequired="'superadmin'">
             <div class="col-12 col-lg-6">
               <ngds-text-input class="mb-4"
                 [control]="form.get('adminNotes')"

--- a/src/app/inventory/product/product-form/product-form.component.ts
+++ b/src/app/inventory/product/product-form/product-form.component.ts
@@ -10,6 +10,7 @@ import { PolicyService } from '../../../services/policy.service';
 import { ActivityService } from '../../../services/activity.service';
 import { ActivityListItemComponent } from '../../activity/activity-list-item/activity-list-item.component';
 import { PolicyListItemComponent } from '../../policy/policy-list-item/policy-list-item.component';
+import { PermissionDirective } from '../../../shared/directives/permission.directive';
 
 @Component({
   selector: 'app-product-form',
@@ -21,6 +22,7 @@ import { PolicyListItemComponent } from '../../policy/policy-list-item/policy-li
     ActivityListItemComponent,
     PolicyListItemComponent,
     LoadalComponent,
+    PermissionDirective
   ],
   templateUrl: './product-form.component.html',
   styleUrl: './product-form.component.scss'

--- a/src/app/inventory/product/product.component.html
+++ b/src/app/inventory/product/product.component.html
@@ -33,12 +33,20 @@
     </div>
     <div class="col-auto mt-3 mt-lg-1 ps-4 pe-4" *ngIf="!isEditing">
       <div class="d-flex justify-content-end align-items-center gap-2">
-        <button class="btn btn-outline-danger rounded-1" (click)="onDelete()">
+        <button 
+          class="btn btn-outline-danger rounded-1"
+          (click)="onDelete()"
+          *permissionRequired="'superadmin'"
+          >
           <div class="col-auto">
             Delete
           </div>
         </button>
-        <button class="btn btn-outline-secondary rounded-1" (click)="navToEdit()">
+        <button 
+          class="btn btn-outline-secondary rounded-1"
+          (click)="navToEdit()"
+          *permissionRequired="'limited'"
+        >
           <div class="col-auto">
             Edit
           </div>

--- a/src/app/inventory/product/product.component.html
+++ b/src/app/inventory/product/product.component.html
@@ -36,7 +36,7 @@
         <button 
           class="btn btn-outline-danger rounded-1"
           (click)="onDelete()"
-          *permissionRequired="'superadmin'"
+          *appPermissionRequired="'superadmin'"
           >
           <div class="col-auto">
             Delete
@@ -45,7 +45,7 @@
         <button 
           class="btn btn-outline-secondary rounded-1"
           (click)="navToEdit()"
-          *permissionRequired="'limited'"
+          *appPermissionRequired="'limited'"
         >
           <div class="col-auto">
             Edit

--- a/src/app/inventory/product/product.component.ts
+++ b/src/app/inventory/product/product.component.ts
@@ -6,10 +6,11 @@ import { ModalRowSpec } from '../../shared/components/search-terms/search-terms.
 import { ConfirmationModalComponent } from '../../shared/components/confirmation-modal/confirmation-modal.component';
 import { BsModalService } from 'ngx-bootstrap/modal';
 import { ProductService } from '../../services/product.service';
+import { PermissionDirective } from '../../shared/directives/permission.directive';
 
 @Component({
   selector: 'app-product',
-  imports: [RouterOutlet, CommonModule],
+  imports: [RouterOutlet, CommonModule, PermissionDirective],
   templateUrl: './product.component.html',
   styleUrl: './product.component.scss',
   providers: [BsModalService],

--- a/src/app/services/activity.service.ts
+++ b/src/app/services/activity.service.ts
@@ -40,6 +40,17 @@ export class ActivityService {
     } catch (error) {
       this.loadingService.removeFromFetchList(Constants.dataIds.ACTIVITY_RESULT);
       this.loggerService.error(error);
+      const errorMessage = 
+        (error as any)?.error?.msg ||
+        (error as any)?.error?.error ||
+        (error as any)?.error?.Message ||
+        (error as any)?.message ||
+        'Unknown error';
+      this.toastService.addMessage(
+        errorMessage,
+        `Activity failed to get`,
+        ToastTypes.ERROR
+      );
       return null;
     }
   }
@@ -60,11 +71,18 @@ export class ActivityService {
     } catch (error) {
       this.loadingService.removeFromFetchList(Constants.dataIds.ACTIVITY_RESULT);
       this.loggerService.error(error);
+      const errorMessage = 
+        (error as any)?.error?.msg ||
+        (error as any)?.error?.error ||
+        (error as any)?.error?.Message ||
+        (error as any)?.message ||
+        'Unknown error';
       this.toastService.addMessage(
-        `${error}`,
+        errorMessage,
         `Activity failed to create`,
         ToastTypes.ERROR
       );
+      return null;
     }
   }
 
@@ -82,12 +100,19 @@ export class ActivityService {
       return res;
     } catch (error) {
       this.loadingService.removeFromFetchList(Constants.dataIds.ACTIVITY_RESULT);
-      this.loggerService.error(error);
+      this.loggerService.error(JSON.stringify(error));
+      const errorMessage = 
+        (error as any)?.error?.msg ||
+        (error as any)?.error?.error ||
+        (error as any)?.error?.Message ||
+        (error as any)?.message ||
+        'Unknown error';
       this.toastService.addMessage(
-        `${error}`,
-        `Activity failed to create`,
+        errorMessage,
+        `Activity failed to update`,
         ToastTypes.ERROR
       );
+      return null;
     }
   }
 
@@ -101,6 +126,18 @@ export class ActivityService {
     } catch (error) {
       this.loadingService.removeFromFetchList(Constants.dataIds.ACTIVITIES_RESULT);
       this.loggerService.error(error);
+      const errorMessage = 
+        (error as any)?.error?.msg ||
+        (error as any)?.error?.error ||
+        (error as any)?.error?.Message ||
+        (error as any)?.message ||
+        'Unknown error';
+      this.toastService.addMessage(
+        errorMessage,
+        `Activity failed to get`,
+        ToastTypes.ERROR
+      );
+      return null;
     }
   }
 
@@ -119,11 +156,18 @@ export class ActivityService {
     } catch (error) {
       this.loadingService.removeFromFetchList(Constants.dataIds.ACTIVITY_RESULT);
       this.loggerService.error(error);
+      const errorMessage = 
+        (error as any)?.error?.msg ||
+        (error as any)?.error?.error ||
+        (error as any)?.error?.Message ||
+        (error as any)?.message ||
+        'Unknown error';
       this.toastService.addMessage(
-        `${error}`,
+        errorMessage,
         `Activity failed to delete`,
         ToastTypes.ERROR
       );
+      return null;
     }
   }
 }

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -2,6 +2,7 @@ import { Injectable, signal } from '@angular/core';
 import { Amplify } from "aws-amplify";
 import { ConfigService } from './config.service';
 import { LoggerService } from './logger.service';
+import { PermissionsService } from './permissions.service';
 import { signInWithRedirect, fetchUserAttributes, fetchAuthSession, signOut } from 'aws-amplify/auth';
 import { Hub } from 'aws-amplify/utils';
 import { Router } from '@angular/router';
@@ -10,22 +11,26 @@ import { Router } from '@angular/router';
   providedIn: 'root'
 })
 export class AuthService {
-  constructor(private configService: ConfigService, private loggerService: LoggerService, private router: Router) {
-  }
+  constructor(
+    private configService: ConfigService,
+    private loggerService: LoggerService,
+    private router: Router,
+    private permissionsService: PermissionsService
+  ) {}
 
-  public user = signal<any>(null); // Make sure observable for user updates
-  public session = signal(null);
+  public user = signal<any>(null);
+  public session = signal<any>(null);
   public reDirectValues;
-  public allAccessRoleName = 'superadmin';
+
+  // Expose signals and helpers from PermissionsService for convenience
+  get permissions() { return this.permissionsService.permissions; }
+  get allAccessRoleName() { return this.permissionsService.allAccessRoleName; }
+  isSuperAdmin() { return this.permissionsService.isSuperAdmin(); }
 
   async init() {
     console.log('this.configService.config:', this.configService.config);
     console.time('timer');
-    if (this.configService.config.ENVIRONMENT === 'local' || !this.configService.config['COGNITO_REDIRECT_URI']) {
-      this.reDirectValues = 'http://localhost:4200';
-    } else {
-      this.reDirectValues = this.configService.config['COGNITO_REDIRECT_URI'];
-    }
+    this.reDirectValues = this.configService.config['COGNITO_REDIRECT_URI'];
     Amplify.configure({
       Auth: {
         Cognito: {
@@ -45,6 +50,7 @@ export class AuthService {
       },
     });
     await this.setRefresh();
+    this.listenToAuthEvents();
     return Promise.resolve();
   }
 
@@ -69,6 +75,7 @@ export class AuthService {
           this.loggerService.info('User has signed in successfully.');
           const session = await fetchAuthSession();
           await this.setRefresh();
+          await this.permissionsService.load(this.session().tokens.accessToken.toString());
           this.router.navigate(['/']);
           console.log('Session:', session);
           break;
@@ -78,6 +85,7 @@ export class AuthService {
           this.loggerService.info('User has signed out successfully.');
           this.updateUser(null);
           this.session.set(null);
+          this.permissionsService.clear();
           break;
         }
         case 'tokenRefresh': {
@@ -114,6 +122,7 @@ export class AuthService {
       this.session.set(await fetchAuthSession({ forceRefresh: forceRefresh }));
       if (this.session().tokens) {
         this.loggerService.debug(JSON.stringify(this.session(), null, 2));
+        await this.permissionsService.load(this.session().tokens.accessToken.toString());
         const refreshInterval = ((this.session().tokens.accessToken.payload.exp * 1000) - Date.now()) / 2;
         if (refreshInterval > 0) {
           setTimeout(async () => {
@@ -152,6 +161,7 @@ export class AuthService {
     await signOut();
     this.updateUser(null);
     this.session.set(null);
+    this.permissionsService.clear();
     console.log('User logged out', this.user);
     this.router.navigate(['/']);
   }

--- a/src/app/services/facility.service.ts
+++ b/src/app/services/facility.service.ts
@@ -33,6 +33,18 @@ export class FacilityService {
     } catch (error) {
       this.loadingService.removeFromFetchList(Constants.dataIds.FACILITY_RESULT);
       this.loggerService.error(error);
+      const errorMessage = 
+        (error as any)?.error?.msg ||
+        (error as any)?.error?.error ||
+        (error as any)?.error?.Message ||
+        (error as any)?.message ||
+        'Unknown error';
+      this.toastService.addMessage(
+        errorMessage,
+        `Facility failed to get`,
+        ToastTypes.ERROR
+      );
+      return null;
     }
   }
 
@@ -46,6 +58,18 @@ export class FacilityService {
     } catch (error) {
       this.loadingService.removeFromFetchList(Constants.dataIds.FACILITIES_RESULT);
       this.loggerService.error(error);
+      const errorMessage = 
+        (error as any)?.error?.msg ||
+        (error as any)?.error?.error ||
+        (error as any)?.error?.Message ||
+        (error as any)?.message ||
+        'Unknown error';
+      this.toastService.addMessage(
+        errorMessage,
+        `Facility failed to get`,
+        ToastTypes.ERROR
+      );
+      return null;
     }
   }
 
@@ -63,12 +87,19 @@ export class FacilityService {
       return res;
     } catch (error) {
       this.loadingService.removeFromFetchList(Constants.dataIds.FACILITY_RESULT);
+      this.loggerService.error(error);
+      const errorMessage = 
+        (error as any)?.error?.msg ||
+        (error as any)?.error?.error ||
+        (error as any)?.error?.Message ||
+        (error as any)?.message ||
+        'Unknown error';
       this.toastService.addMessage(
-        `${error}`,
+        errorMessage,
         `Facility failed to create`,
         ToastTypes.ERROR
       );
-      this.loggerService.error(error);
+      return null;
     }
   }
 
@@ -87,7 +118,12 @@ export class FacilityService {
     } catch (error) {
       this.loadingService.removeFromFetchList(Constants.dataIds.FACILITY_RESULT);
       this.loggerService.error(error);
-      const errorMessage = (error as any)?.error?.msg || (error as any)?.error?.error || (error as any)?.message || 'Unknown error';
+      const errorMessage = 
+        (error as any)?.error?.msg ||
+        (error as any)?.error?.error ||
+        (error as any)?.error?.Message ||
+        (error as any)?.message ||
+        'Unknown error';
       this.toastService.addMessage(
         errorMessage,
         `Facility failed to update`,
@@ -111,12 +147,18 @@ export class FacilityService {
       return res;
     } catch (error) {
       this.loadingService.removeFromFetchList(Constants.dataIds.FACILITY_RESULT);
-      this.loggerService.error(error);
+      const errorMessage = 
+        (error as any)?.error?.msg ||
+        (error as any)?.error?.error ||
+        (error as any)?.error?.Message ||
+        (error as any)?.message ||
+        'Unknown error';
       this.toastService.addMessage(
-        `${error}`,
+        errorMessage,
         `Facility failed to delete`,
         ToastTypes.ERROR
       );
+      return null;
     }
   }
 }

--- a/src/app/services/feature-flag.service.ts
+++ b/src/app/services/feature-flag.service.ts
@@ -6,7 +6,7 @@ import { LoggerService } from './logger.service';
 export interface FeatureFlagMetadata {
   lastUpdated: string;
   updatedBy: string;
-  updatedByEmail: string;
+  updatedByUsername: string;
 }
 
 export interface FeatureFlagAdminResponse {

--- a/src/app/services/permissions.service.spec.ts
+++ b/src/app/services/permissions.service.spec.ts
@@ -1,0 +1,3 @@
+xdescribe('logger.service legacy placeholder', () => {
+  it('skipped', () => {});
+});

--- a/src/app/services/permissions.service.ts
+++ b/src/app/services/permissions.service.ts
@@ -1,0 +1,78 @@
+import { Injectable, signal } from '@angular/core';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { firstValueFrom } from 'rxjs';
+import { ConfigService } from './config.service';
+import { LoggerService } from './logger.service';
+import { ToastService } from './toast.service';
+import { LoadingService } from './loading.service';
+
+const TIER_RANK: Record<string, number> = { limited: 1, staff: 2, superadmin: 99 };
+
+@Injectable({
+  providedIn: 'root',
+})
+export class PermissionsService {
+  public permissions = signal<Record<string, string> | null>(null);
+
+  readonly allAccessRoleName = 'superadmin';
+
+  constructor(
+    protected loadingService: LoadingService,
+    private configService: ConfigService,
+    private http: HttpClient,
+    protected loggerService: LoggerService,
+    protected toastService: ToastService
+  ) { }
+
+  async load(token) {
+    try {
+      const apiLocation = this.configService.config['API_LOCATION'];
+      const apiPath = this.configService.config['API_PATH'];
+      const baseUrl = (apiPath && apiLocation !== 'http://localhost:3000')
+        ? apiLocation + apiPath
+        : apiLocation;
+      const headers = new HttpHeaders({
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      });
+      const res = await firstValueFrom(this.http.get(`${baseUrl}/users/me`, { headers })) as any;
+      this.loggerService.debug(`Permissions loaded: ${JSON.stringify(res)}`);
+      this.permissions.set(res?.data?.permissions ?? null);
+    } catch (error) {
+      this.loggerService.error(`Error loading permissions: ${error}`);
+      this.permissions.set(null);
+    }
+  }
+
+  clear() {
+    this.permissions.set(null);
+  }
+
+  // Send back if the user is staff (or superadmin) for conditional UI rendering
+  isAdmin() {
+    const perms = this.permissions();
+    return perms?.[this.allAccessRoleName] === this.allAccessRoleName;
+  }
+
+  isSuperAdmin() {
+    return this.permissions()?.[this.allAccessRoleName] === this.allAccessRoleName;
+  }
+
+  // Check whether the user meets a minimum tier requirement
+  // If collectionId is provided the check is scoped to that collection only,
+  // otherwise it passes if the user has the tier on any collection they manage
+  hasPermission(required, collectionId?) {
+    if (this.isSuperAdmin()) return true;
+
+    const perms = this.permissions();
+    if (!perms) return false;
+
+    const requiredRank = TIER_RANK[required] ?? 0;
+
+    if (collectionId) {
+      return (TIER_RANK[perms[collectionId]] ?? 0) >= requiredRank;
+    }
+
+    return Object.values(perms).some(tier => (TIER_RANK[tier] ?? 0) >= requiredRank);
+  }
+}

--- a/src/app/services/product.service.ts
+++ b/src/app/services/product.service.ts
@@ -49,6 +49,17 @@ export class ProductService {
     } catch (error) {
       this.loadingService.removeFromFetchList(Constants.dataIds.PRODUCT_RESULT);
       this.loggerService.error(error);
+      const errorMessage = 
+        (error as any)?.error?.msg ||
+        (error as any)?.error?.error ||
+        (error as any)?.error?.Message ||
+        (error as any)?.message ||
+        'Unknown error';
+      this.toastService.addMessage(
+        errorMessage,
+        `Product failed to get`,
+        ToastTypes.ERROR
+      );
       return null;
     }
   }
@@ -71,6 +82,17 @@ export class ProductService {
     } catch (error) {
       this.loadingService.removeFromFetchList(Constants.dataIds.PRODUCT_LIST);
       this.loggerService.error(error);
+      const errorMessage = 
+        (error as any)?.error?.msg ||
+        (error as any)?.error?.error ||
+        (error as any)?.error?.Message ||
+        (error as any)?.message ||
+        'Unknown error';
+      this.toastService.addMessage(
+        errorMessage,
+        `Product failed to get`,
+        ToastTypes.ERROR
+      );
       return null;
     }
   }
@@ -89,8 +111,15 @@ export class ProductService {
       return res;
     } catch (error) {
       this.loadingService.removeFromFetchList(Constants.dataIds.PRODUCT_RESULT);
+      this.loggerService.error(error);
+      const errorMessage = 
+        (error as any)?.error?.msg ||
+        (error as any)?.error?.error ||
+        (error as any)?.error?.Message ||
+        (error as any)?.message ||
+        'Unknown error';
       this.toastService.addMessage(
-        `${error}`,
+        errorMessage,
         `Product failed to create`,
         ToastTypes.ERROR
       );
@@ -113,7 +142,12 @@ export class ProductService {
     } catch (error) {
       this.loadingService.removeFromFetchList(Constants.dataIds.PRODUCT_RESULT);
       this.loggerService.error(error);
-      const errorMessage = (error as any)?.error?.msg || (error as any)?.error?.error || (error as any)?.message || 'Unknown error';
+      const errorMessage = 
+        (error as any)?.error?.msg ||
+        (error as any)?.error?.error ||
+        (error as any)?.error?.Message ||
+        (error as any)?.message ||
+        'Unknown error';
       this.toastService.addMessage(
         errorMessage,
         `Product failed to update`,
@@ -138,7 +172,12 @@ export class ProductService {
     } catch (error) {
       this.loadingService.removeFromFetchList(Constants.dataIds.PRODUCT_RESULT);
       this.loggerService.error(error);
-      const errorMessage = (error as any)?.error?.msg || (error as any)?.error?.error || (error as any)?.message || 'Unknown error';
+      const errorMessage = 
+        (error as any)?.error?.msg ||
+        (error as any)?.error?.error ||
+        (error as any)?.error?.Message ||
+        (error as any)?.message ||
+        'Unknown error';
       this.toastService.addMessage(
         errorMessage,
         `Product failed to delete`,

--- a/src/app/shared/components/sidebar/sidebar.component.html
+++ b/src/app/shared/components/sidebar/sidebar.component.html
@@ -1,13 +1,13 @@
 <nav class="h-100 bg-secondary text-white" id="sidebar">
   <div class="d-flex flex-column h-100 pb-3">
       <ul class="list-unstyled components ms-3 pe-3">
-        <li><a routerLink="/dashboard"><i class="fa-solid fa-gauge"></i> Dashboard</a></li>
-        <li><a routerLink="/sales"><i class="fa-solid fa-cash-register"></i> Sales</a></li>
-        <li><a routerLink="/reports"><i class="fa-solid fa-chart-bar"></i> Reports</a></li>
-        <li><a routerLink="/inventory"><i class="fa-solid fa-boxes-stacked"></i> Inventory</a></li>
-        <li><a routerLink="/customers"><i class="fa-solid fa-users"></i> Customers</a></li>
-        <ng-container *ngIf="isAdmin()">
-          <li class="mt-3 mb-1"><small class="text-white-50">Settings</small></li>
+        <li><a routerLink="/dashboard" *permissionRequired="'limited'"><i class="fa-solid fa-gauge"></i> Dashboard</a></li>
+        <li><a routerLink="/sales" *permissionRequired="'superadmin'"><i class="fa-solid fa-cash-register"></i> Sales</a></li>
+        <li><a routerLink="/reports" *permissionRequired="'limited'"><i class="fa-solid fa-chart-bar"></i> Reports</a></li>
+        <li><a routerLink="/inventory" *permissionRequired="'limited'"><i class="fa-solid fa-user"></i> Inventory</a></li>
+        <li><a routerLink="/customers" *permissionRequired="'staff'"><i class="fa-solid fa-users"></i> Customers</a></li>
+        <ng-container *permissionRequired="'superadmin'">
+          <li class="mt-3 mb-1"><small class="text-white-50">Superadmin Settings</small></li>
           <li><a routerLink="/admin/feature-flags"><i class="fa-solid fa-toggle-on"></i> Feature Flags</a></li>
           <li><a routerLink="/admin/waiting-room"><i class="fa-solid fa-door-open"></i> Waiting Room</a></li>
         </ng-container>

--- a/src/app/shared/components/sidebar/sidebar.component.html
+++ b/src/app/shared/components/sidebar/sidebar.component.html
@@ -1,12 +1,12 @@
 <nav class="h-100 bg-secondary text-white" id="sidebar">
   <div class="d-flex flex-column h-100 pb-3">
       <ul class="list-unstyled components ms-3 pe-3">
-        <li><a routerLink="/dashboard" *permissionRequired="'limited'"><i class="fa-solid fa-gauge"></i> Dashboard</a></li>
-        <li><a routerLink="/sales" *permissionRequired="'superadmin'"><i class="fa-solid fa-cash-register"></i> Sales</a></li>
-        <li><a routerLink="/reports" *permissionRequired="'limited'"><i class="fa-solid fa-chart-bar"></i> Reports</a></li>
-        <li><a routerLink="/inventory" *permissionRequired="'limited'"><i class="fa-solid fa-user"></i> Inventory</a></li>
-        <li><a routerLink="/customers" *permissionRequired="'staff'"><i class="fa-solid fa-users"></i> Customers</a></li>
-        <ng-container *permissionRequired="'superadmin'">
+        <li><a routerLink="/dashboard" *appPermissionRequired="'limited'"><i class="fa-solid fa-gauge"></i> Dashboard</a></li>
+        <li><a routerLink="/sales" *appPermissionRequired="'superadmin'"><i class="fa-solid fa-cash-register"></i> Sales</a></li>
+        <li><a routerLink="/reports" *appPermissionRequired="'limited'"><i class="fa-solid fa-chart-bar"></i> Reports</a></li>
+        <li><a routerLink="/inventory" *appPermissionRequired="'limited'"><i class="fa-solid fa-user"></i> Inventory</a></li>
+        <li><a routerLink="/customers" *appPermissionRequired="'staff'"><i class="fa-solid fa-users"></i> Customers</a></li>
+        <ng-container *appPermissionRequired="'superadmin'">
           <li class="mt-3 mb-1"><small class="text-white-50">Superadmin Settings</small></li>
           <li><a routerLink="/admin/feature-flags"><i class="fa-solid fa-toggle-on"></i> Feature Flags</a></li>
           <li><a routerLink="/admin/waiting-room"><i class="fa-solid fa-door-open"></i> Waiting Room</a></li>

--- a/src/app/shared/components/sidebar/sidebar.component.ts
+++ b/src/app/shared/components/sidebar/sidebar.component.ts
@@ -1,16 +1,17 @@
-import { Component, HostBinding, OnInit, signal } from '@angular/core';
+import { Component, HostBinding } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Router, RouterModule } from '@angular/router';
-import { AuthService } from '../../../services/auth.service';
+import { PermissionsService } from '../../../services/permissions.service';
+import { PermissionDirective } from '../../directives/permission.directive';
 
 @Component({
   selector: 'app-sidebar',
   templateUrl: './sidebar.component.html',
   styleUrls: ['./sidebar.component.scss'],
   standalone: true,
-  imports: [CommonModule, RouterModule]
+  imports: [CommonModule, RouterModule, PermissionDirective]
 })
-export class SidebarComponent implements OnInit {
+export class SidebarComponent {
   @HostBinding('class.is-toggled')
   public hide = false;
 
@@ -22,19 +23,13 @@ export class SidebarComponent implements OnInit {
     { path: 'customers', data: { label: 'Customers' } }
   ];
   public currentRoute: any;
-  public isAdmin = signal<boolean>(false);
 
   constructor(
     protected router: Router,
-    private authService: AuthService
-  ) {
-    
-  }
+    protected permissionsService: PermissionsService
+  ) {}
 
-  async ngOnInit(): Promise<void> {
-    const isAdmin = await this.authService.userIsAdmin();
-    this.isAdmin.set(isAdmin);
-  }
+  ngOnInit(): void {}
 
   onNavigate(route) {
   }

--- a/src/app/shared/components/sidebar/sidebar.component.ts
+++ b/src/app/shared/components/sidebar/sidebar.component.ts
@@ -29,11 +29,7 @@ export class SidebarComponent {
     protected permissionsService: PermissionsService
   ) {}
 
-  ngOnInit(): void {}
-
-  onNavigate(route) {
-  }
-
+  onNavigate(route) {}
 
   getPathFromUrl(url) {
     return url.split('?')[0];

--- a/src/app/shared/directives/permission.directive.ts
+++ b/src/app/shared/directives/permission.directive.ts
@@ -1,0 +1,73 @@
+import {
+  Directive,
+  effect,
+  Input,
+  TemplateRef,
+  ViewContainerRef,
+} from '@angular/core';
+import { PermissionsService } from '../../services/permissions.service';
+
+/**
+ * Structural directive that shows an element only when the current user
+ * meets the required permission tier for an optional collection.
+ *
+ * Usage:
+ *   <!-- Minimum tier required, any collection -->
+ *   <button *permissionRequired="'staff'">Edit</button>
+ *
+ *   <!-- Scoped to a specific collection -->
+ *   <button *permissionRequired="'staff'; collection: collectionId">Edit</button>
+ *
+ *   <!-- No argument — visible to any authenticated user with any permission -->
+ *   <div *permissionRequired>...</div>
+ *
+ * The directive re-evaluates reactively whenever the permissions signal changes
+ * (e.g. after login, logout, or token refresh).
+ */
+@Directive({
+  selector: '[permissionRequired]',
+  standalone: true,
+})
+export class PermissionDirective {
+  private requiredTier: string | null = null;
+  private collectionId: string | null = null;
+
+  @Input() set permissionRequired(tier: string | null | undefined) {
+    this.requiredTier = tier ?? null;
+    this.update();
+  }
+
+  @Input() set permissionRequiredCollection(collectionId: string | null | undefined) {
+    this.collectionId = collectionId ?? null;
+    this.update();
+  }
+
+  constructor(
+    private templateRef: TemplateRef<unknown>,
+    private viewContainer: ViewContainerRef,
+    private permissionsService: PermissionsService
+  ) {
+    // Re-evaluate whenever the permissions signal changes
+    effect(() => {
+      this.permissionsService.permissions();
+      this.update();
+    });
+  }
+
+  private update() {
+    const allowed = this.requiredTier
+      ? this.permissionsService.hasPermission(
+          this.requiredTier,
+          this.collectionId ?? undefined
+        )
+      : this.permissionsService.permissions() !== null;
+
+    if (allowed) {
+      if (this.viewContainer.length === 0) {
+        this.viewContainer.createEmbeddedView(this.templateRef);
+      }
+    } else {
+      this.viewContainer.clear();
+    }
+  }
+}

--- a/src/app/shared/directives/permission.directive.ts
+++ b/src/app/shared/directives/permission.directive.ts
@@ -13,31 +13,31 @@ import { PermissionsService } from '../../services/permissions.service';
  *
  * Usage:
  *   <!-- Minimum tier required, any collection -->
- *   <button *permissionRequired="'staff'">Edit</button>
+ *   <button *appPermissionRequired="'staff'">Edit</button>
  *
  *   <!-- Scoped to a specific collection -->
- *   <button *permissionRequired="'staff'; collection: collectionId">Edit</button>
+ *   <button *appPermissionRequired="'staff'; collection: collectionId">Edit</button>
  *
  *   <!-- No argument — visible to any authenticated user with any permission -->
- *   <div *permissionRequired>...</div>
+ *   <div *appPermissionRequired>...</div>
  *
  * The directive re-evaluates reactively whenever the permissions signal changes
  * (e.g. after login, logout, or token refresh).
  */
 @Directive({
-  selector: '[permissionRequired]',
+  selector: '[appPermissionRequired]',
   standalone: true,
 })
 export class PermissionDirective {
   private requiredTier: string | null = null;
   private collectionId: string | null = null;
 
-  @Input() set permissionRequired(tier: string | null | undefined) {
+  @Input() set appPermissionRequired(tier: string | null | undefined) {
     this.requiredTier = tier ?? null;
     this.update();
   }
 
-  @Input() set permissionRequiredCollection(collectionId: string | null | undefined) {
+  @Input() set appPermissionRequiredCollection(collectionId: string | null | undefined) {
     this.collectionId = collectionId ?? null;
     this.update();
   }


### PR DESCRIPTION
### Ticket:

PRDT-172

### Ticket URL:

#172

### Description:
- Added roles and permissions check for several components (geozones, facilities, activities, and products)
  - Uses the `permissions.directive` and the `*permissionRequired` flag on elements to load or hide elements based on the user's permissions
  - Added similar check and logic for showing items in the `sidebar` component.
- Update the `user.guard` and `admin.guard` and created a `permission.guard` to check if a user can reach certain collectionId routes
- Also updated some service errors to have useful messages in the Toast