### PR TITLE
PRDT-172-1: Fix logic for viewing edit buttons with facilities and products

### DIFF
--- a/src/app/inventory/facility/facility.component.html
+++ b/src/app/inventory/facility/facility.component.html
@@ -45,7 +45,7 @@
         <button 
           class="btn btn-outline-secondary rounded-1"
           (click)="navToEdit()"
-          *appPermissionRequired="'staff'"
+          *appPermissionRequired="'staff' ; collection: data?.collectionId"
         >
           <div class="col-auto">
             Edit

--- a/src/app/inventory/product/product.component.html
+++ b/src/app/inventory/product/product.component.html
@@ -45,7 +45,7 @@
         <button 
           class="btn btn-outline-secondary rounded-1"
           (click)="navToEdit()"
-          *appPermissionRequired="'limited'"
+          *appPermissionRequired="'limited' ; collection: data?.collectionId"
         >
           <div class="col-auto">
             Edit


### PR DESCRIPTION
- Fix the "Edit" button from showing when a user has both `staff` and `limited` permissions for different collections.
- User will only see the "Edit" button if they are 'staff' AND have access to that collection based on their permissions.