### PR TITLE
feat(prod): CDK-based prod deploy workflow + LZA OAC bucket policy fix

### DIFF
--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -13,6 +13,13 @@ permissions:
   id-token: write
   contents: read
 
+concurrency:
+  group: deploy-reserve-rec-admin-prod
+  cancel-in-progress: false
+
+env:
+  S3_BUCKET: ${{ vars.S3_BUCKET }}
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -22,15 +29,43 @@ jobs:
       matrix:
         node-version: [20.x]
     steps:
+      ### Restore cdk.out cache
+      - name: Restore cdk.out cache
+        uses: actions/cache@v4
+        with:
+          path: cdk.out
+          # A static cache key is fine since cdk deploy will overwrite files as needed
+          key: ${{ runner.os }}-prod-cdk-out
+          restore-keys: |
+            ${{ runner.os }}-prod-cdk-out
+
       ### Checkout GitHub Repo
       - name: Checkout repo
         uses: actions/checkout@v4
 
-      # - shell: bash
-      #   env:
-      #     WEBHOOK_URL: ${{ secrets.WEBHOOK_URL }}
-      #   run: |
-      #     curl -X POST -H 'Content-Type: application/json' $WEBHOOK_URL --data '{"text":"Reserve Rec - Deploy Admin Prod"}'
+      - name: Install AWS CDK
+        run: |
+          yarn
+          yarn global add aws-cdk
+
+      ### Assume AWS IAM Role
+      - name: Get AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-session-name: GitHub_to_AWS_via_FederatedOIDC
+          aws-region: ${{ vars.AWS_REGION }}
+
+      ### CDK Deploy
+      - name: CDK Deploy
+        run: export LOG_LEVEL=debug && cdk deploy -c @context=prod --all --require-approval never --rollback
+
+      ### Save cdk.out cache
+      - name: Save cdk.out cache
+        uses: actions/cache@v4
+        with:
+          path: cdk.out
+          key: ${{ runner.os }}-prod-cdk-out
 
       ### Install if no cache exists ###
       - name: Setup node
@@ -38,9 +73,10 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: "yarn"
+          cache-dependency-path: "yarn.lock"
       - run: yarn install --silent --frozen-lockfile
 
-      ### Build if no cache exists ###
+      ### Build ###
       - name: Cache Build
         id: cache-build
         uses: actions/cache@v4
@@ -56,74 +92,20 @@ jobs:
           sed 's@localConfigEndpoint@'true'@g' src/env.js.template | sed 's@localGHHash@'"$GH_HASH"'@g' > src/env.js
           yarn build
 
-      ### Setup AWS SAM
-      - name: Setup AWS SAM
-        uses: aws-actions/setup-sam@v2
-        with:
-          use-installer: true
-
-      ### Assume AWS IAM Role
-      - name: Get AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          role-session-name: GitHub_to_AWS_via_FederatedOIDC
-          aws-region: ${{ vars.AWS_REGION }}
-
-      ### SAM Build
-      - name: Cache SAM Build
-        id: cache-sam-build
-        uses: actions/cache@v4
-        with:
-          path: |
-            **.aws-sam
-          key: ${{ github.sha }}-sam-cache
-      - name: Run sam build
-        if: steps.cache-sam-build.outputs.cache-hit != 'true'
-        run: |
-          sam build --cached
-
-      ### Prevent prompts and failure when the stack is unchanged
-      - name: SAM deploy
-        env:
-          STACK_NAME: ${{ vars.STACK_NAME }}
-          DIST_ORIGIN_PATH: "latest"
-          API_GATEWAY_ID: ${{ vars.API_GATEWAY_ID }}
-          ENV: ${{ vars.ENVIRONMENT_STAGE }}
-          AWS_REGION: ${{ vars.AWS_REGION }}
-          API_STAGE: ${{ vars.API_STAGE }}
-          DOMAIN_NAME: ${{ vars.DOMAIN_NAME }}
-          AWS_CERTIFICATE_ARN: ${{ vars.AWS_CERTIFICATE_ARN }}
-          API_CACHE_POLICY_ID: ${{ vars.API_CACHE_POLICY_ID }}
-        run: |
-          sam deploy --stack-name $STACK_NAME --no-confirm-changeset --no-fail-on-empty-changeset --parameter-overrides \
-          DistOriginPath=$DIST_ORIGIN_PATH \
-          ApiGatewayId=$API_GATEWAY_ID \
-          Env=$ENV \
-          AWSRegion=$AWS_REGION \
-          ApiStage=$API_STAGE \
-          EnvDomainName=$DOMAIN_NAME \
-          DomainCertificateArn=$AWS_CERTIFICATE_ARN \
-          ApiCachePolicyId=$API_CACHE_POLICY_ID \
-
       ### Upload dist to S3 ###
       - name: Deploy to S3
         env:
-          S3_BUCKET: ${{ vars.STACK_NAME }}-${{ vars.ENVIRONMENT_STAGE }}
           DIR_NAME: ${{ github.sha }}
         run: |
+          echo "Deploying to $S3_BUCKET/$DIR_NAME"
           aws s3 sync dist s3://$S3_BUCKET/$DIR_NAME
           aws s3 rm s3://$S3_BUCKET/ --recursive --exclude "*" --include "latest/*"
           aws s3 sync dist s3://$S3_BUCKET/latest
 
-      - name: Invalidate CloudFront
-        uses: chetan/invalidate-cloudfront-action@v2
+      ### Invalidate CloudFront Cache ###
+      - name: Invalidate CloudFront Cache
         env:
-          DISTRIBUTION: ${{ secrets.DISTRIBUTION }}
-          PATHS: "/*"
-
-      # - shell: bash
-      #   env:
-      #     WEBHOOK_URL: ${{ secrets.WEBHOOK_URL }}
-      #   run: |
-      #     curl -X POST -H 'Content-Type: application/json' $WEBHOOK_URL --data '{"text":"Reserve Rec - Deploy Admin Prod Complete"}'
+          DISTRIBUTION_ID: ${{ vars.CLOUDFRONT_DISTRIBUTION_ID }}
+        run: |
+          echo "Invalidating CloudFront Distribution ID: $DISTRIBUTION_ID"
+          aws cloudfront create-invalidation --distribution-id $DISTRIBUTION_ID --paths "/*"

--- a/lib/distribution-stack/distribution-stack.js
+++ b/lib/distribution-stack/distribution-stack.js
@@ -2,6 +2,7 @@ const { logger, StackPrimer, resolveParameterFromSSM } = require("../helpers/uti
 const { BaseStack } = require('../helpers/base-stack');
 const { RemovalPolicy } = require('aws-cdk-lib');
 const s3 = require('aws-cdk-lib/aws-s3');
+const iam = require('aws-cdk-lib/aws-iam');
 const { Key } = require('aws-cdk-lib/aws-kms');
 const cloudfront = require('aws-cdk-lib/aws-cloudfront');
 const origins = require('aws-cdk-lib/aws-cloudfront-origins');
@@ -116,6 +117,48 @@ class DistributionStack extends BaseStack {
       ]
     });
 
+    // Manually add OAC bucket policy statement using a wildcard distribution ARN.
+    //
+    // Why: when S3BucketOrigin.withOriginAccessControl() is used with a concrete bucket,
+    // CDK auto-generates an AWS::S3::BucketPolicy statement whose condition references the
+    // specific distribution ARN (Ref: 'AdminDistribution'). This creates a circular dependency:
+    // the bucket policy can only be created AFTER the distribution, which takes ~3 minutes.
+    // In the BCGov LZA (Landing Zone Accelerator) environment, LZA automatically adds its own
+    // SSL-enforcement bucket policy within ~10 seconds of bucket creation. By the time CDK's
+    // bucket policy is ready to be created, LZA has already set the policy, and CloudFormation
+    // fails with "The bucket policy already exists."
+    //
+    // Fix: add the OAC statement immediately after bucket creation using StringLike with a
+    // wildcard distribution ARN (`arn:aws:cloudfront::${account}:distribution/*`). This only
+    // depends on AWS::AccountId (a pseudo-parameter available immediately), not on the
+    // distribution resource, so the bucket policy can be created in the same early wave as the
+    // bucket itself — before LZA fires.
+    //
+    // The CloudFront origin uses an imported bucket reference (below) so CDK does not add the
+    // auto-generated specific-ARN statement that would re-introduce the circular dependency.
+    this.distBucket.addToResourcePolicy(new iam.PolicyStatement({
+      sid: 'AllowCloudFrontOACRead',
+      effect: iam.Effect.ALLOW,
+      principals: [new iam.ServicePrincipal('cloudfront.amazonaws.com')],
+      actions: ['s3:GetObject'],
+      resources: [this.distBucket.arnForObjects('*')],
+      conditions: {
+        StringLike: {
+          'AWS:SourceArn': `arn:aws:cloudfront::${this.account}:distribution/*`,
+        },
+      },
+    }));
+
+    // Imported bucket reference used as the CloudFront S3 origin.
+    // CDK cannot add bucket policies to imported buckets (logs a warning and skips), which is
+    // intentional here — it prevents CDK from generating a second, specific-ARN OAC statement
+    // that would reintroduce the circular dependency. The actual distBucket uses the
+    // wildcard OAC statement added above.
+    const distBucketForOrigin = s3.Bucket.fromBucketAttributes(this, 'DistBucketForOrigin', {
+      bucketArn: this.distBucket.bucketArn,
+      bucketName: this.distBucket.bucketName,
+    });
+
     // Define S3 Log Bucket
     this.logBucket = new s3.Bucket(this, this.getConstructId('logBucket'), {
       bucketName: `${this.getConstructId('logBucket').toLowerCase()}-logs`,
@@ -152,7 +195,7 @@ class DistributionStack extends BaseStack {
       enabled: true,
       httpVersion: cloudfront.HttpVersion.HTTP2,
       defaultBehavior: {
-        origin: origins.S3BucketOrigin.withOriginAccessControl(this.distBucket, {
+        origin: origins.S3BucketOrigin.withOriginAccessControl(distBucketForOrigin, {
           originPath: 'latest/reserve-rec-admin/browser',
           originAccessControl: this.originAccessControl,
           customHeaders: {


### PR DESCRIPTION
- Replace SAM-based deploy-prod.yaml with CDK + S3 sync + CloudFront invalidation workflow, matching the test workflow pattern
- Fix LZA race condition in distribution-stack: add OAC bucket policy with wildcard distribution ARN immediately after bucket creation, before LZA's SSL-enforcement automation fires; use imported bucket ref for CF origin to suppress CDK's auto-generated specific-ARN statement
- Add concurrency guard and cdk.out cache to prod workflow

Fixes #270