### PR TITLE
fix(ws): use correct jwtToken getter on AuthService

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -28,7 +28,7 @@ export function initConfig(
     await apiService.init();
     await featureFlagService.init();
     const wsUrl = configService.config['WEBSOCKET_URL'];
-    const wsToken = authService.getAccessToken();
+    const wsToken = authService.jwtToken;
     await websocketService.init(wsToken ? `${wsUrl}?token=${wsToken}` : wsUrl);
   };
 }


### PR DESCRIPTION
Fixes build error from #226 — `getAccessToken` doesn't exist on `AuthService`; the correct getter is `jwtToken`.

Ref #218