### PR TITLE
fix(inventory): guard against undefined vcr in generateMapMarkerHTML

### DIFF
--- a/src/app/inventory/inventory-search/inventory-search.component.ts
+++ b/src/app/inventory/inventory-search/inventory-search.component.ts
@@ -346,6 +346,9 @@ export class InventorySearchComponent implements OnInit, AfterViewChecked, OnDes
   }
 
   async generateMapMarkerHTML(options, data = null) {
+    if (!this.vcr) {
+      return this.oldMapMarkerHTML(options, data);
+    }
     const el2 = this.vcr.createComponent(MapMarkerComponent);
     el2.setInput('markerData', data);
     el2.setInput('markerOptions', options);


### PR DESCRIPTION
Fall back to `oldMapMarkerHTML` when `vcr` (ViewContainerRef) is not yet initialized — happens when `generateMapMarkerHTML` is called via an Angular `effect()` before `ngAfterViewInit` completes.