### PR TITLE
fix(ws): skip WebSocket init if no URL configured

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -28,8 +28,10 @@ export function initConfig(
     await apiService.init();
     await featureFlagService.init();
     const wsUrl = configService.config['WEBSOCKET_URL'];
-    const wsToken = authService.jwtToken;
-    await websocketService.init(wsToken ? `${wsUrl}?token=${wsToken}` : wsUrl);
+    if (wsUrl) {
+      const wsToken = authService.jwtToken;
+      await websocketService.init(wsToken ? `${wsUrl}?token=${wsToken}` : wsUrl);
+    }
   };
 }
 


### PR DESCRIPTION
Guard against connecting when `WEBSOCKET_URL` is absent from config — previously produced a broken `undefined?token=...` URL.