### PR TITLE
fix(product): transform numberOfPasses and estimationMode on edit

### DIFF
--- a/src/app/inventory/product/product-edit/product-edit.component.ts
+++ b/src/app/inventory/product/product-edit/product-edit.component.ts
@@ -94,6 +94,25 @@ export class ProductEditComponent extends EntityEditBaseComponent implements Aft
     // Handle search terms
     props['searchTerms'] = this.productForm.get('searchTerms')?.value || [];
 
+    // Transform numberOfPasses into assetList, preserving existing primaryKey/allocationType.
+    if (props['numberOfPasses'] !== undefined) {
+      const existing = this.product?.assetList?.[0];
+      props['assetList'] = [{
+        ...existing,
+        quantity: Number(props['numberOfPasses']),
+      }];
+      delete props['numberOfPasses'];
+    }
+
+    // Transform estimationMode into availabilityEstimationPattern, preserving cadence/tiers.
+    if (props['estimationMode']) {
+      props['availabilityEstimationPattern'] = {
+        ...this.product?.availabilityEstimationPattern,
+        estimationMode: props['estimationMode'],
+      };
+      delete props['estimationMode'];
+    }
+
     for (const policy of ['reservationPolicy', 'partyPolicy', 'feePolicy', 'changePolicy']) {
       if (props[policy]) {
         props[policy] = {


### PR DESCRIPTION
- `numberOfPasses` → `assetList[0].quantity` (preserves primaryKey/allocationType)
- `estimationMode` → `availabilityEstimationPattern` (preserves cadence/tiers)
- Same transformation already exists on create (#237); edit was missed, so API rejected with `Field 'numberOfPasses' is not allowed`

Ref #210