### PR TITLE
fix(search): build correct route for product results

### DIFF
--- a/src/app/inventory/search-results-table/search-result/search-result.component.ts
+++ b/src/app/inventory/search-results-table/search-result/search-result.component.ts
@@ -65,7 +65,7 @@ export class SearchResultComponent {
         route = `inventory/activity/${data?.collectionId}/${data?.activityType}/${data?.activityId}`;
         break;
       case 'product':
-        route = `inventory/product/${data.id}`;
+        route = `inventory/product/${data?.collectionId}/${data?.activityType}/${data?.activityId}/${data?.productId}`;
         break;
       case 'geozone':
         route = `inventory/geozone/${data?.collectionId}/${data?.geozoneId}`;


### PR DESCRIPTION
- Was using `data.id` (OpenSearch `_id` = `pk#sk`), producing a single-segment URL the router couldn't match (NG04002)
- Now matches the activity case: `${collectionId}/${activityType}/${activityId}/${productId}`
- Found while testing #210 — clicking a product search result currently fails to navigate