### PR TITLE
fix(distribution): SPA fallback for deep links via viewer-request fn

### DIFF
--- a/lib/distribution-stack/distribution-stack.js
+++ b/lib/distribution-stack/distribution-stack.js
@@ -207,6 +207,30 @@ class DistributionStack extends BaseStack {
     //   enableAcceptEncodingGzip: true,
     // });
 
+    // SPA fallback for direct deep links. The S3 REST origin returns 403 (not 404)
+    // for missing keys, so the distribution-level 404→/index.html error response
+    // doesn't fire and users see raw S3 AccessDenied XML. Rewriting extension-less
+    // URIs to /index.html in viewer-request lets Angular Router resolve the path
+    // client-side. We can't just add 403→/index.html at the distribution level
+    // because it would also rewrite legitimate 403s from /api/* (admin auth errors).
+    const spaFallbackFn = new cloudfront.Function(this, this.getConstructId('spaFallbackFn'), {
+      functionName: `ReserveRecAdmin-${this.getDeploymentName()}-SpaFallbackFn`,
+      runtime: cloudfront.FunctionRuntime.JS_2_0,
+      code: cloudfront.FunctionCode.fromInline([
+        'function handler(event) {',
+        '  var request = event.request;',
+        '  var uri = request.uri;',
+        '  // Rewrite paths without a file extension in the last segment to /index.html',
+        '  // so Angular Router can take over. Static assets like /main-abc.js pass through.',
+        '  if (uri.length > 1 && uri.lastIndexOf(\'.\') < uri.lastIndexOf(\'/\')) {',
+        '    request.uri = \'/index.html\';',
+        '  }',
+        '  return request;',
+        '}',
+      ].join('\n')),
+      comment: `SPA deep-link fallback for ${this.getDeploymentName()}`,
+    });
+
     // CloudFront Distribution
     this.adminDistribution = new cloudfront.Distribution(this, this.getConstructId('adminDistribution'), {
       distributionName: this.getConstructId('adminDistribution'),
@@ -225,7 +249,10 @@ class DistributionStack extends BaseStack {
         viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
         responseHeadersPolicy: cloudfront.ResponseHeadersPolicy.CORS_ALLOW_ALL_ORIGINS,
         cachePolicy: cloudfront.CachePolicy.CACHING_DISABLED,
-
+        functionAssociations: [{
+          function: spaFallbackFn,
+          eventType: cloudfront.FunctionEventType.VIEWER_REQUEST,
+        }],
       },
       comment: `Reserve Rec Admin CloudFront Distribution (${this.getDeploymentName()})`,
       compress: true,


### PR DESCRIPTION
- S3 REST origin returns `403 AccessDenied` for missing keys, so the distribution-level `404→/index.html` error response never fires for Angular deep links — users saw raw S3 XML
- Adds a CloudFront viewer-request Function on the default behavior that rewrites extension-less URIs to `/index.html`, letting Angular Router resolve the path client-side
- Doesn't touch `/api/*` (separate behavior, function not associated), so legitimate admin auth `403`s still pass through to clients

Note: the public distribution likely has the same gap; could add the same pattern there as a follow-up (would need to merge with the existing waiting-room viewer-request function on that behavior).