### PR TITLE
fix(distribution): register spaFallbackFn in constructs registry

### DIFF
--- a/lib/distribution-stack/distribution-stack.js
+++ b/lib/distribution-stack/distribution-stack.js
@@ -33,6 +33,9 @@ const defaults = {
     cloudFrontCachePolicy: {
       name: 'CloudFrontCachePolicy',
     },
+    spaFallbackFn: {
+      name: 'SpaFallbackFn',
+    },
     adminDistribution: {
       name: 'AdminDistribution',
     },


### PR DESCRIPTION
- Follow-up to #242 — that PR added a new cloudfront.Function but didn't register its key in `defaults.constructs`
- `getConstructId('spaFallbackFn')` returned `null`, was silently passed as the Function's construct ID, and synth produced an incomplete template that omitted the distribution itself
- Result: dev deploy deleted the existing dev distribution. Test was unaffected (no tag pushed)
- This PR adds the registry entry so synth produces the expected template

After merge: dev deploy will recreate the distribution with a new ID. The repo variable `CLOUDFRONT_DISTRIBUTION_ID` needs to be updated to the new ID afterward (the invalidation step in the dev workflow currently 404s).