### PR TITLE
fix(toast): show readable error messages instead of [object Object]

### DIFF
--- a/src/app/services/geozone.service.ts
+++ b/src/app/services/geozone.service.ts
@@ -6,6 +6,7 @@ import { LoadingService } from './loading.service';
 import { ApiService } from './api.service';
 import { LoggerService } from './logger.service';
 import { ToastService, ToastTypes } from './toast.service';
+import { errorMessage } from '../utils/utils';
 
 @Injectable({
   providedIn: 'root'
@@ -65,7 +66,7 @@ export class GeozoneService {
     } catch (error) {
       this.loadingService.removeFromFetchList(Constants.dataIds.GEOZONE_RESULT);
       this.toastService.addMessage(
-        `${error}`,
+        errorMessage(error),
         `Geozone failed to create`,
         ToastTypes.ERROR
       );
@@ -87,7 +88,7 @@ export class GeozoneService {
       return res;
     } catch (error) {
       this.toastService.addMessage(
-        `${error}`,
+        errorMessage(error),
         `Geozone failed to update`,
         ToastTypes.ERROR
       );
@@ -112,7 +113,7 @@ export class GeozoneService {
       this.loadingService.removeFromFetchList(Constants.dataIds.GEOZONE_RESULT);
       this.loggerService.error(error);
       this.toastService.addMessage(
-        `${error}`,
+        errorMessage(error),
         `Geozone failed to delete`,
         ToastTypes.ERROR
       );

--- a/src/app/services/reports.service.ts
+++ b/src/app/services/reports.service.ts
@@ -5,6 +5,7 @@ import { ApiService } from './api.service';
 import { LoggerService } from './logger.service';
 import { ToastService, ToastTypes } from './toast.service';
 import { lastValueFrom } from 'rxjs';
+import { errorMessage } from '../utils/utils';
 
 @Injectable({
   providedIn: 'root'
@@ -37,7 +38,7 @@ export class ReportsService {
       this.loadingService.removeFromFetchList(dataTag);
       this.loggerService.error(error);
       this.toastService.addMessage(
-        `${error}`,
+        errorMessage(error),
         'Failed to fetch daily passes report',
         ToastTypes.ERROR
       );

--- a/src/app/services/search.service.ts
+++ b/src/app/services/search.service.ts
@@ -6,6 +6,7 @@ import { LoggerService } from './logger.service';
 import { ApiService } from './api.service';
 import { LoadingService } from './loading.service';
 import { ToastService, ToastTypes } from './toast.service';
+import { errorMessage } from '../utils/utils';
 
 @Injectable({
   providedIn: 'root'
@@ -45,7 +46,7 @@ export class SearchService {
       return res; // Return the results for further processing if needed
     } catch (error) {
       this.toastService.addMessage(
-        `${error}`,
+        errorMessage(error),
         `Search error`,
         ToastTypes.ERROR
       );

--- a/src/app/utils/utils.ts
+++ b/src/app/utils/utils.ts
@@ -156,3 +156,23 @@ export class Utils {
     return str;
   }
 }
+
+/**
+ * Pulls a human-readable string out of an error of unknown shape.
+ * Without this, `${error}` on an HttpErrorResponse renders as
+ * "[object Object]" in toasts (issue #190 — session timeout case).
+ */
+export function errorMessage(error: any, fallback = 'An unexpected error occurred'): string {
+  if (!error) return fallback;
+  if (typeof error === 'string') return error;
+  // HttpErrorResponse or generic object — walk the usual nested shapes
+  return (
+    error?.error?.msg ||
+    error?.error?.error ||
+    error?.error?.Message ||
+    error?.error?.message ||
+    error?.message ||
+    error?.statusText ||
+    fallback
+  );
+}


### PR DESCRIPTION
Several services rendered caught errors via `${error}`, which coerces HttpErrorResponse objects to "[object Object]" — most visible on session timeout. New `errorMessage()` helper walks the usual nested shapes; used in search, reports, and geozone services. Ref #190