### PR TITLE
fix(inventory): drop ngAfterViewChecked detectChanges workaround

### DIFF
--- a/src/app/inventory/create-inventory/create-inventory.component.ts
+++ b/src/app/inventory/create-inventory/create-inventory.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewChecked, ChangeDetectorRef, Component } from '@angular/core';
+import { Component } from '@angular/core';
 import { Router, RouterOutlet } from '@angular/router';
 import { CreateInventorySelectorComponent } from './create-inventory-selector/create-inventory-selector.component';
 import { CommonModule } from '@angular/common';
@@ -9,18 +9,9 @@ import { CommonModule } from '@angular/common';
   templateUrl: './create-inventory.component.html',
   styleUrl: './create-inventory.component.scss'
 })
-export class CreateInventoryComponent implements AfterViewChecked{
+export class CreateInventoryComponent {
 
-  constructor(
-    protected router: Router,
-    protected cdr: ChangeDetectorRef
-  ) {}
-
-  ngAfterViewChecked(): void {
-    // This is a workaround to ensure that the router outlet is updated after the view is checked
-    // This is necessary because the router outlet may not update immediately after navigation
-    this.cdr.detectChanges();
-  }
+  constructor(protected router: Router) {}
 
   showSelectionOptions(): boolean {
     const urlParts = this.router.url.split('/');


### PR DESCRIPTION
CreateInventoryComponent was calling cdr.detectChanges() in ngAfterViewChecked, which runs on every CD pass and interfered with router-outlet child activation. Removing it restores the expected behaviour: /create/facility → back → /create/product now renders the product form. Ref #189