### PR TITLE
fix(activity): populate sub-type options on edit

### DIFF
--- a/src/app/inventory/activity/activity-form/activity-form.component.ts
+++ b/src/app/inventory/activity/activity-form/activity-form.component.ts
@@ -100,6 +100,11 @@ export class ActivityFormComponent implements OnInit, AfterViewChecked {
     this.form.get('activityType').valueChanges.subscribe(() => {
       this.updateFilteredActivitySubTypes();
     });
+
+    // Populate the sub-type dropdown for the existing activityType when editing.
+    // Without this, the form has the activitySubType value set but the picklist
+    // has no options to display it against, so the field appears empty.
+    this.updateFilteredActivitySubTypes();
   }
 
 


### PR DESCRIPTION
Sub-type dropdown options were only populated in response to activityType valueChanges. On edit the value is patched in (not changed), so the dropdown stayed empty. Calls updateFilteredActivitySubTypes() once after form init. Ref #221