### PR TITLE
fix(inventory-search): correct subTypes typo and guard undefined

### DIFF
--- a/src/app/inventory/inventory-search/inventory-search.component.ts
+++ b/src/app/inventory/inventory-search/inventory-search.component.ts
@@ -221,8 +221,12 @@ export class InventorySearchComponent implements OnInit, AfterViewChecked, OnDes
   }
 
   getFacilitySubTypeOptions() {
-    const facilityType = this.form.get('filters.facilityType').value;
-    return Object.entries(Constants.facilityTypes[facilityType].subtypes);
+    const facilityType = this.form.get('filters.facilityType')?.value;
+    // Note: Constants uses camelCase `subTypes`. The previous lowercase
+    // access (`.subtypes`) returned undefined, and Object.entries(undefined)
+    // throws — this fired during change detection if a facility-type filter
+    // was set, leaving the page stuck behind the loading overlay.
+    return Object.entries(Constants.facilityTypes[facilityType]?.subTypes || {});
   }
 
   getActivitySubTypeOptions() {


### PR DESCRIPTION
getFacilitySubTypeOptions read `.subtypes` (lowercase) — Constants use `subTypes` (camelCase), so the property was undefined and `Object.entries(undefined)` threw on every CD cycle when a facility-type filter was set. Fix uses camelCase + empty-object fallback. Ref #191