### PR TITLE
PRDT-206: Clean up Change Detection across components

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,12 @@
+### Ticket:
+
+PRDT-
+
+### Ticket URL:
+
+#
+
+### Description:
+-
+- 
+-

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -33,13 +33,10 @@ export class HomeComponent implements OnInit, AfterViewChecked, OnDestroy {
       console.log(e);
     } finally {
       this.checkingSession = false;
-      this.cdr.detectChanges();
     }
   }
 
   ngAfterViewChecked(): void {
-    //Called after every check of the component's view. Applies to components only.
-    //Add 'implements AfterViewChecked' to the class.
     this.cdr.detectChanges()
   }
 

--- a/src/app/inventory/activity/activity-form/activity-form.component.ts
+++ b/src/app/inventory/activity/activity-form/activity-form.component.ts
@@ -121,8 +121,6 @@ export class ActivityFormComponent implements OnInit, AfterViewChecked {
   }
 
   ngAfterViewChecked(): void {
-    //Called after every check of the component's view. Applies to components only.
-    //Add 'implements AfterViewChecked' to the class.
     this.cdr.detectChanges()
   }
 

--- a/src/app/inventory/geozone/geozone-form/geozone-form.component.ts
+++ b/src/app/inventory/geozone/geozone-form/geozone-form.component.ts
@@ -124,8 +124,6 @@ export class GeozoneFormComponent implements OnInit, AfterViewInit, AfterViewChe
   }
 
   ngAfterViewChecked(): void {
-    //Called after every check of the component's view. Applies to components only.
-    //Add 'implements AfterViewChecked' to the class.
     this.cdr.detectChanges()
   }
 

--- a/src/app/reports/daily-passes/daily-passes-report.component.ts
+++ b/src/app/reports/daily-passes/daily-passes-report.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewChecked, ChangeDetectorRef, Component, OnInit } from '@angular/core';
+import { AfterViewChecked, ChangeDetectorRef, Component, OnDestroy, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ReactiveFormsModule, FormBuilder, Validators } from '@angular/forms';
 import { NgdsFormsModule } from '@digitalspace/ngds-forms';
@@ -37,7 +37,7 @@ interface DailyPassRecord {
   templateUrl: './daily-passes-report.component.html',
   styleUrl: './daily-passes-report.component.scss'
 })
-export class DailyPassesReportComponent implements OnInit, AfterViewChecked {
+export class DailyPassesReportComponent implements OnInit, AfterViewChecked, OnDestroy {
   form = this.fb.group({
     collectionId: this.fb.control('', { nonNullable: true, validators: [Validators.required], updateOn: 'blur' }),
     facilityId: [''],
@@ -80,8 +80,6 @@ export class DailyPassesReportComponent implements OnInit, AfterViewChecked {
   }
 
   ngAfterViewChecked(): void {
-    //Called after every check of the component's view. Applies to components only.
-    //Add 'implements AfterViewChecked' to the class.
     this.cdr.detectChanges();
   }
 
@@ -262,5 +260,10 @@ export class DailyPassesReportComponent implements OnInit, AfterViewChecked {
     const month = String(date.getMonth() + 1).padStart(2, '0');
     const day = String(date.getDate()).padStart(2, '0');
     return `${year}-${month}-${day}`;
+  }
+
+  ngOnDestroy(): void {
+    this.cdr.detectChanges()
+    this.cdr.detach()
   }
 }


### PR DESCRIPTION
### Ticket:

PRDT-206

### Ticket URL:

#206 

### Description:
- Remove redundant `cdr.detectChanges()` call from HomeComponent's `ngOnInit` `finally` block
- Remove boilerplate comments from `ngAfterViewChecked` in activity-form, geozone-form, and daily-passes-report components
- Add `ngOnDestroy` to DailyPassesReportComponent to detach change detector on cleanup