### PR TITLE
PRDT-249: Replace LoadalComponent with inline loading states

### DIFF
--- a/src/app/admin/feature-flags/feature-flags.component.html
+++ b/src/app/admin/feature-flags/feature-flags.component.html
@@ -6,10 +6,8 @@
     </div>
   </div>
 
-  <div *ngIf="loading" class="text-center py-5">
-    <div class="spinner-border" role="status">
-      <span class="visually-hidden">Loading...</span>
-    </div>
+  <div *ngIf="loading" class="text-center mb-3 text-muted">
+    <i class="fa fa-spinner fa-spin me-2"></i>
   </div>
 
   <div *ngIf="!loading">

--- a/src/app/admin/feature-flags/feature-flags.component.ts
+++ b/src/app/admin/feature-flags/feature-flags.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectorRef, Component, OnDestroy, OnInit } from '@angular/core';
+import { AfterViewChecked, ChangeDetectorRef, Component, OnDestroy, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule, ReactiveFormsModule, UntypedFormGroup, UntypedFormControl } from '@angular/forms';
 import { BsModalService } from 'ngx-bootstrap/modal';
@@ -23,7 +23,7 @@ interface FlagDefinition {
   templateUrl: './feature-flags.component.html',
   styleUrls: ['./feature-flags.component.scss']
 })
-export class FeatureFlagsComponent implements OnInit, OnDestroy {
+export class FeatureFlagsComponent implements OnInit, AfterViewChecked, OnDestroy {
   loading = true;
   saving = false;
 
@@ -45,12 +45,16 @@ export class FeatureFlagsComponent implements OnInit, OnDestroy {
     private toastService: ToastService,
     private loadingService: LoadingService,
     private modalService: BsModalService,
-    private cd: ChangeDetectorRef
+    private cdr: ChangeDetectorRef
   ) { }
 
   async ngOnInit(): Promise<void> {
     await this.loadFlags();
     this.loading = false;
+  }
+
+  ngAfterViewChecked(): void {
+    this.cdr.detectChanges()
   }
 
   async loadFlags(): Promise<void> {
@@ -136,7 +140,7 @@ export class FeatureFlagsComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy(): void {
-    this.cd.detectChanges(); // Force this component to unload
-    this.cd.detach();
+    this.cdr.detectChanges(); // Force this component to unload
+    this.cdr.detach();
   }
 }

--- a/src/app/customers/customers.component.html
+++ b/src/app/customers/customers.component.html
@@ -29,10 +29,8 @@
   </div>
 
   <!-- Loading Spinner -->
-  <div *ngIf="loading && customers.length === 0" class="text-center py-5">
-    <div class="spinner-border" role="status">
-      <span class="visually-hidden">Loading...</span>
-    </div>
+  <div *ngIf="loading && customers.length === 0" class="text-center mb-3 text-muted">
+    <i class="fa fa-spinner fa-spin me-2"></i>
   </div>
 
   <!-- No Results -->

--- a/src/app/inventory/activity/activity-form/activity-form.component.html
+++ b/src/app/inventory/activity/activity-form/activity-form.component.html
@@ -1,6 +1,3 @@
-<!-- Loading indicator - always present but only shows when loading -->
-<app-loadal #loadal></app-loadal>
-
 <!-- Main form container - only shown when form is initialized -->
 <div *ngIf="form">
   <!-- STEP 1: Collection ID Selection -->

--- a/src/app/inventory/activity/activity-form/activity-form.component.ts
+++ b/src/app/inventory/activity/activity-form/activity-form.component.ts
@@ -11,7 +11,6 @@ import { UntypedFormControl, UntypedFormGroup, Validators } from '@angular/forms
 import { NgdsFormsModule } from '@digitalspace/ngds-forms';
 import { CommonModule } from '@angular/common';
 import { LoadingService } from '../../../services/loading.service';
-import { LoadalComponent } from '../../../shared/components/loadal/loadal.component';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Constants } from '../../../app.constants';
 import { SearchTermsComponent } from '../../../shared/components/search-terms/search-terms.component';
@@ -19,12 +18,11 @@ import { CollectionSelectorComponent } from '../../../shared/components/collecti
 
 @Component({
   selector: 'app-activity-form',
-  imports: [NgdsFormsModule, CommonModule, LoadalComponent, SearchTermsComponent, CollectionSelectorComponent],
+  imports: [NgdsFormsModule, CommonModule, SearchTermsComponent, CollectionSelectorComponent],
   templateUrl: './activity-form.component.html',
   styleUrls: ['./activity-form.component.scss']
 })
 export class ActivityFormComponent implements OnInit, AfterViewChecked {
-  @ViewChild('loadal', { static: true }) loadal!: LoadalComponent;
   @ViewChild('searchTerms', { static: false }) searchTermsComponent!: SearchTermsComponent;
 
   @Output() formValue: EventEmitter<any> = new EventEmitter<any>();

--- a/src/app/inventory/collection/collection-edit/collection-edit.component.html
+++ b/src/app/inventory/collection/collection-edit/collection-edit.component.html
@@ -1,4 +1,3 @@
-<app-loadal #loadal></app-loadal>
 <app-collection-form
   [collection]="collection"
   (formValue)="updateCollectionForm($event)">
@@ -20,8 +19,9 @@
       <button
         class="btn btn-primary rounded-1"
         (click)="submit()"
-        [disabled]="!collectionForm?.valid || !collectionForm?.dirty">
-        Save
+        [disabled]="!collectionForm?.valid || !collectionForm?.dirty || isSubmitting">
+        <i *ngIf="isSubmitting" class="fa fa-spinner fa-spin me-2"></i>
+        {{ isSubmitting ? 'Saving...' : 'Save' }}
       </button>
     </div>
   </div>

--- a/src/app/inventory/collection/collection-edit/collection-edit.component.ts
+++ b/src/app/inventory/collection/collection-edit/collection-edit.component.ts
@@ -4,20 +4,20 @@ import { CollectionService } from '../../../services/collection.service';
 import { RelationshipService } from '../../../services/relationship.service';
 import { ActivatedRoute, Router } from '@angular/router';
 import { EntityEditBaseComponent } from '../../../shared/components/entity/entity-base/entity-edit-base.component';
-import { LoadalComponent } from '../../../shared/components/loadal/loadal.component';
+import { NgIf } from '@angular/common';
 
 @Component({
   selector: 'app-collection-edit',
-  imports: [CollectionFormComponent, LoadalComponent],
+  imports: [CollectionFormComponent, NgIf],
   templateUrl: './collection-edit.component.html',
   styleUrl: './collection-edit.component.scss'
 })
 export class CollectionEditComponent extends EntityEditBaseComponent implements AfterViewChecked {
   @ViewChild(CollectionFormComponent) collectionFormComponent!: CollectionFormComponent;
-  @ViewChild('loadal', { static: true }) loadal!: LoadalComponent;
 
   public collectionForm;
   public collection;
+  public isSubmitting = false;
 
   constructor(
     protected collectionService: CollectionService,
@@ -53,7 +53,7 @@ export class CollectionEditComponent extends EntityEditBaseComponent implements 
 
     const collectionId = this.collection?.collectionId;
 
-    this.loadal.show();
+    this.isSubmitting = true;
     try {
       const props = this.formatFormForSubmission();
 
@@ -65,7 +65,7 @@ export class CollectionEditComponent extends EntityEditBaseComponent implements 
     } catch (error) {
       console.error('Error updating collection:', error);
     } finally {
-      this.loadal.hide();
+      this.isSubmitting = false;
     }
   }
 

--- a/src/app/inventory/collection/collection-form/collection-form.component.html
+++ b/src/app/inventory/collection/collection-form/collection-form.component.html
@@ -1,4 +1,3 @@
-<app-loadal #loadal></app-loadal>
 <section class="container pt-3 pb-3">
   <div class="row">
     <div class="col-12">

--- a/src/app/inventory/collection/collection-form/collection-form.component.ts
+++ b/src/app/inventory/collection/collection-form/collection-form.component.ts
@@ -5,13 +5,12 @@ import { NgdsFormsModule } from '@digitalspace/ngds-forms';
 import { CollectionService } from '../../../services/collection.service';
 import { Constants } from '../../../app.constants';
 import { SearchTermsComponent } from '../../../shared/components/search-terms/search-terms.component';
-import { LoadalComponent } from '../../../shared/components/loadal/loadal.component';
 import { LoadingService } from '../../../services/loading.service';
 import { PermissionDirective } from '../../../shared/directives/permission.directive';
 
 @Component({
   selector: 'app-collection-form',
-  imports: [CommonModule, ReactiveFormsModule, NgdsFormsModule, SearchTermsComponent, LoadalComponent, PermissionDirective],
+  imports: [CommonModule, ReactiveFormsModule, NgdsFormsModule, SearchTermsComponent, PermissionDirective],
   templateUrl: './collection-form.component.html',
   styleUrl: './collection-form.component.scss'
 })

--- a/src/app/inventory/create-inventory/collection-create/collection-create.component.html
+++ b/src/app/inventory/create-inventory/collection-create/collection-create.component.html
@@ -1,4 +1,3 @@
-<app-loadal #loadal></app-loadal>
 <section class="container pt-3 pb-3">
   <div class="row">
     <div class="col-12">
@@ -14,8 +13,15 @@
 </app-collection-form>
 <section>
   <div class="d-flex flex-column align-items-center justify-content-center mt-2 mb-5">
-    <button class="btn btn-outline-success btn-lg" (click)="submit()" [disabled]="!collectionForm?.valid">
-      <span>Create Collection</span>
+    <button class="d-flex justify-content-center gap-2 btn btn-outline-success btn-lg" (click)="submit()" [disabled]="!collectionForm?.valid || isSubmitting">
+    <span>{{ isSubmitting ? 'Creating...' : 'Create Collection' }}</span>
+      <div 
+        class="spinner-border"
+        role="status"
+        *ngIf="isSubmitting"
+      >
+        <span class="sr-only">Creating...</span>
+      </div>
     </button>
   </div>
 </section>

--- a/src/app/inventory/create-inventory/collection-create/collection-create.component.ts
+++ b/src/app/inventory/create-inventory/collection-create/collection-create.component.ts
@@ -1,35 +1,39 @@
-import { Component, ViewChild } from '@angular/core';
+import { AfterViewChecked, ChangeDetectorRef, Component } from '@angular/core';
 import { Router } from '@angular/router';
 import { CollectionService } from '../../../services/collection.service';
 import { CollectionFormComponent } from '../../collection/collection-form/collection-form.component';
-import { LoadalComponent } from '../../../shared/components/loadal/loadal.component';
 import { UntypedFormGroup } from '@angular/forms';
 import { ToastService, ToastTypes } from '../../../services/toast.service';
+import { NgIf } from '@angular/common';
 
 @Component({
   selector: 'app-collection-create',
-  imports: [CollectionFormComponent, LoadalComponent],
+  imports: [CollectionFormComponent, NgIf],
   templateUrl: './collection-create.component.html',
   styleUrl: './collection-create.component.scss'
 })
-export class CollectionCreateComponent {
-  @ViewChild('loadal', { static: true }) loadal!: LoadalComponent
-
+export class CollectionCreateComponent implements AfterViewChecked {
   public collectionForm: UntypedFormGroup;
   public collection;
+  public isSubmitting = false;
 
   constructor(
     protected collectionService: CollectionService,
     protected router: Router,
-    protected toastService: ToastService
+    protected toastService: ToastService,
+    private cdr: ChangeDetectorRef
   ) { }
+
+  ngAfterViewChecked(): void {
+    this.cdr.detectChanges()
+  }
 
   updateCollectionForm(event) {
     this.collectionForm = event;
   }
 
   async submit() {
-    this.loadal.show();
+    this.isSubmitting = true;
     try {
       const props = this.formatFormForSubmission();
       const res = await this.collectionService.createCollection(props);
@@ -40,7 +44,7 @@ export class CollectionCreateComponent {
     } catch (error) {
       console.error('Error creating collection:', error);
     } finally {
-      this.loadal.hide();
+      this.isSubmitting = false;
     }
   }
 

--- a/src/app/inventory/create-inventory/facility-create/facility-create.component.html
+++ b/src/app/inventory/create-inventory/facility-create/facility-create.component.html
@@ -1,4 +1,3 @@
-<app-loadal #loadal></app-loadal>
 <section class="container pt-3 pb-3">
   <div class="row">
     <div class="col-12">
@@ -14,8 +13,9 @@
 </app-facility-form>
 <section>
   <div class="d-flex flex-column align-items-center justify-content-center mt-2 mb-5">
-    <button class="btn btn-outline-success btn-lg" (click)="submit()" [disabled]="!facilityForm?.valid">
-      <span>Create Facility</span>
+    <button class="btn btn-outline-success btn-lg" (click)="submit()" [disabled]="!facilityForm?.valid || isSubmitting">
+      <i *ngIf="isSubmitting" class="fa fa-spinner fa-spin me-2"></i>
+      <span>{{ isSubmitting ? 'Creating...' : 'Create Facility' }}</span>
     </button>
   </div>
 </section>

--- a/src/app/inventory/create-inventory/facility-create/facility-create.component.ts
+++ b/src/app/inventory/create-inventory/facility-create/facility-create.component.ts
@@ -1,22 +1,21 @@
-import { ChangeDetectorRef, Component, ViewChild } from '@angular/core';
+import { ChangeDetectorRef, Component } from '@angular/core';
 import { UntypedFormGroup } from '@angular/forms';
 import { FacilityService } from '../../../services/facility.service';
 import { ActivatedRoute, Router } from '@angular/router';
 import { FacilityFormComponent } from '../../facility/facility-form/facility-form.component';
-import { LoadalComponent } from '../../../shared/components/loadal/loadal.component';
+import { NgIf } from '@angular/common';
 
 @Component({
   selector: 'app-facility-create',
-  imports: [FacilityFormComponent, LoadalComponent],
+  imports: [FacilityFormComponent, NgIf],
   templateUrl: './facility-create.component.html',
   styleUrl: './facility-create.component.scss'
 })
 export class FacilityCreateComponent {
-  @ViewChild('loadal', { static: true }) loadal!: LoadalComponent;
-
   public facilityForm: UntypedFormGroup;
   public facility;
   public isCreating: boolean = true;
+  public isSubmitting = false;
 
   constructor(
     protected facilityService: FacilityService,
@@ -60,7 +59,7 @@ export class FacilityCreateComponent {
       return;
     }
 
-    this.loadal.show();
+    this.isSubmitting = true;
     try {
       const props = this.formatFormForSubmission();
       const res = await this.facilityService.createFacility(collectionId, facilityType, props);
@@ -72,7 +71,7 @@ export class FacilityCreateComponent {
     } catch (error) {
       console.error('Error creating facility:', error);
     } finally {
-      this.loadal.hide();
+      this.isSubmitting = false;
     }
   }
 

--- a/src/app/inventory/create-inventory/product-create/product-create.component.html
+++ b/src/app/inventory/create-inventory/product-create/product-create.component.html
@@ -1,4 +1,3 @@
-<app-loadal #loadal></app-loadal>
 <section class="container pt-3 pb-3">
   <div class="row">
     <div class="col-12">
@@ -14,10 +13,13 @@
 </app-product-form>
 <section>
   <div class="d-flex flex-column align-items-center justify-content-center mt-2 mb-5">
-    <button class="btn btn-outline-success btn-lg" (click)="submit()" [disabled]="!productForm?.valid">
-      <span>Create Product</span>
+    <div *ngIf="isSubmitting" class="text-center mb-3 text-muted">
+      <i class="fa fa-spinner fa-spin me-2"></i>
+      <span class="fs-5">{{ submitStep }}</span>
+    </div>
+    <button class="btn btn-outline-success btn-lg" (click)="submit()" [disabled]="!productForm?.valid || isSubmitting">
+      <i *ngIf="isSubmitting" class="fa fa-spinner fa-spin me-2"></i>
+      <span>{{ isSubmitting ? 'Creating...' : 'Create Product' }}</span>
     </button>
   </div>
 </section>
-
-

--- a/src/app/inventory/create-inventory/product-create/product-create.component.ts
+++ b/src/app/inventory/create-inventory/product-create/product-create.component.ts
@@ -1,22 +1,22 @@
-import { ChangeDetectorRef, Component, ViewChild } from '@angular/core';
+import { ChangeDetectorRef, Component } from '@angular/core';
 import { UntypedFormGroup } from '@angular/forms';
 import { ProductService } from '../../../services/product.service';
 import { ActivatedRoute, Router } from '@angular/router';
 import { ProductFormComponent } from '../../product/product-form/product-form.component';
-import { LoadalComponent } from '../../../shared/components/loadal/loadal.component';
 import { ToastService, ToastTypes } from '../../../services/toast.service';
+import { NgIf } from '@angular/common';
 
 @Component({
   selector: 'app-product-create',
-  imports: [ProductFormComponent, LoadalComponent],
+  imports: [ProductFormComponent, NgIf],
   templateUrl: './product-create.component.html',
   styleUrl: './product-create.component.scss'
 })
 export class ProductCreateComponent {
-  @ViewChild('loadal', { static: true }) loadal!: LoadalComponent;
-
   public productForm: UntypedFormGroup;
   public product;
+  public isSubmitting = false;
+  public submitStep: string | null = null;
 
   constructor(
     protected productService: ProductService,
@@ -83,7 +83,8 @@ export class ProductCreateComponent {
       return;
     }
 
-    this.loadal.show();
+    this.isSubmitting = true;
+    this.submitStep = 'Creating product...';
     try {
       // Step 1: Create the product
       const props = this.formatFormForSubmission();
@@ -95,6 +96,7 @@ export class ProductCreateComponent {
       }
 
       // Step 2: Create product dates
+      this.submitStep = 'Setting up product dates...';
       const productDatesResult = await this.productService.createProductDates(
         collectionId,
         activityType,
@@ -110,6 +112,7 @@ export class ProductCreateComponent {
       }
 
       // Step 3: Create inventory pools
+      this.submitStep = 'Building inventory pools...';
       const inventoryPoolsResult = await this.productService.createInventoryPools(
         collectionId,
         activityType,
@@ -131,7 +134,8 @@ export class ProductCreateComponent {
     } catch (error) {
       console.error('Error in product creation workflow:', error);
     } finally {
-      this.loadal.hide();
+      this.isSubmitting = false;
+      this.submitStep = null;
     }
   }
 

--- a/src/app/inventory/create-inventory/relationship-create/relationship-create.component.html
+++ b/src/app/inventory/create-inventory/relationship-create/relationship-create.component.html
@@ -1,4 +1,3 @@
-<app-loadal #loadal></app-loadal>
 
 <section>
   <div class="d-flex flex-column align-items-center justify-content-center my-5">

--- a/src/app/inventory/create-inventory/relationship-create/relationship-create.component.ts
+++ b/src/app/inventory/create-inventory/relationship-create/relationship-create.component.ts
@@ -1,10 +1,9 @@
-import { Component, OnInit, ViewChild, ChangeDetectorRef, effect, signal, untracked, input } from '@angular/core';
+import { Component, OnInit, ChangeDetectorRef, effect, signal, untracked, input, AfterViewChecked } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { UntypedFormControl, UntypedFormGroup, Validators } from '@angular/forms';
 import { Router, ActivatedRoute } from '@angular/router';
 import { CommonModule } from '@angular/common';
 import { NgdsFormsModule } from '@digitalspace/ngds-forms';
-import { LoadalComponent } from '../../../shared/components/loadal/loadal.component';
 import { EntityRelationshipSelectorComponent } from '../../../shared/components/entity/entity-relationship-selector/entity-relationship-selector.component';
 import { RelationshipService } from '../../../services/relationship.service';
 import { ActivityService } from '../../../services/activity.service';
@@ -15,13 +14,11 @@ import { Constants } from '../../../app.constants';
 @Component({
   selector: 'app-relationship-create',
   standalone: true,
-  imports: [CommonModule, NgdsFormsModule, LoadalComponent, EntityRelationshipSelectorComponent],
+  imports: [CommonModule, NgdsFormsModule, EntityRelationshipSelectorComponent],
   templateUrl: './relationship-create.component.html',
   styleUrls: ['./relationship-create.component.scss']
 })
-export class RelationshipCreateComponent {
-  @ViewChild('loadal') loadal!: LoadalComponent;
-
+export class RelationshipCreateComponent implements AfterViewChecked {
   public form: UntypedFormGroup;
 
   // Use signals to track and subscribe to changes
@@ -141,6 +138,10 @@ export class RelationshipCreateComponent {
         });
       }
     });
+  }
+
+  ngAfterViewChecked(): void {
+    this.cdr.detectChanges()      
   }
 
   initializeForm() {

--- a/src/app/inventory/facility/facility-edit/facility-edit.component.html
+++ b/src/app/inventory/facility/facility-edit/facility-edit.component.html
@@ -1,4 +1,3 @@
-<app-loadal #loadal></app-loadal>
 <app-facility-form
   (formValue)="updateFacilityForm($event)"
   (relationshipsLoaded)="onRelationshipsLoaded($event.type, $event.relationships)"
@@ -21,8 +20,9 @@
       <button
         class="btn btn-primary rounded-1"
         (click)="submit()"
-        [disabled]="!facilityForm?.valid || !facilityForm?.dirty">
-        Save
+        [disabled]="!facilityForm?.valid || !facilityForm?.dirty || isSubmitting">
+        <i *ngIf="isSubmitting" class="fa fa-spinner fa-spin me-2"></i>
+        {{ isSubmitting ? 'Saving...' : 'Save' }}
       </button>
     </div>
   </div>

--- a/src/app/inventory/facility/facility-edit/facility-edit.component.ts
+++ b/src/app/inventory/facility/facility-edit/facility-edit.component.ts
@@ -4,20 +4,20 @@ import { FacilityService } from '../../../services/facility.service';
 import { RelationshipService } from '../../../services/relationship.service';
 import { ActivatedRoute, Router } from '@angular/router';
 import { EntityEditBaseComponent } from '../../../shared/components/entity/entity-base/entity-edit-base.component';
-import { LoadalComponent } from '../../../shared/components/loadal/loadal.component';
+import { NgIf } from '@angular/common';
 
 @Component({
   selector: 'app-facility-edit',
-  imports: [FacilityFormComponent, LoadalComponent],
+  imports: [FacilityFormComponent, NgIf],
   templateUrl: './facility-edit.component.html',
   styleUrl: './facility-edit.component.scss'
 })
 export class FacilityEditComponent extends EntityEditBaseComponent implements AfterViewChecked {
   @ViewChild(FacilityFormComponent) facilityFormComponent!: FacilityFormComponent;
-  @ViewChild('loadal', { static: true }) loadal!: LoadalComponent;
 
   public facilityForm;
   public facility;
+  public isSubmitting = false;
 
   constructor(
     protected facilityService: FacilityService,
@@ -55,7 +55,7 @@ export class FacilityEditComponent extends EntityEditBaseComponent implements Af
     const facilityType = this.facility?.facilityType;
     const facilityId = this.facility?.facilityId;
 
-    this.loadal.show();
+    this.isSubmitting = true;
     try {
       const props = this.formatFormForSubmission();
 
@@ -74,7 +74,7 @@ export class FacilityEditComponent extends EntityEditBaseComponent implements Af
     } catch (error) {
       console.error('Error updating facility:', error);
     } finally {
-      this.loadal.hide();
+      this.isSubmitting = false;
     }
   }
 

--- a/src/app/inventory/facility/facility-form/facility-form.component.html
+++ b/src/app/inventory/facility/facility-form/facility-form.component.html
@@ -1,4 +1,3 @@
-<app-loadal #loadal></app-loadal>
 <section class="container pt-3 pb-3">
   <div class="row">
     <div class="col-12">

--- a/src/app/inventory/facility/facility-form/facility-form.component.ts
+++ b/src/app/inventory/facility/facility-form/facility-form.component.ts
@@ -1,6 +1,5 @@
 import { AfterViewChecked, ChangeDetectorRef, Component, effect, EventEmitter, Input, OnInit, Output, signal, TemplateRef, ViewChild, WritableSignal } from '@angular/core';
 import { MapComponent } from '../../../map/map.component';
-import { LoadalComponent } from '../../../shared/components/loadal/loadal.component';
 import { Constants } from '../../../app.constants';
 import { LoadingService } from '../../../services/loading.service';
 import { ActivatedRoute, Router } from '@angular/router';
@@ -21,7 +20,6 @@ import { PermissionDirective } from '../../../shared/directives/permission.direc
   imports: [
     NgdsFormsModule,
     MapComponent,
-    LoadalComponent,
     CommonModule,
     SearchTermsComponent,
     CollectionSelectorComponent,
@@ -37,7 +35,6 @@ import { PermissionDirective } from '../../../shared/directives/permission.direc
 })
 export class FacilityFormComponent extends EntityFormBaseComponent implements OnInit, AfterViewChecked {
   @ViewChild('mapComponent', { static: true }) mapComponent!: MapComponent;
-  @ViewChild('loadal', { static: true }) loadal!: LoadalComponent;
   @ViewChild('searchTerms', { static: false }) searchTermsComponent!: SearchTermsComponent;
 
   @ViewChild('activityItemTemplate') activityItemTemplate: TemplateRef<any>;
@@ -259,7 +256,7 @@ export class FacilityFormComponent extends EntityFormBaseComponent implements On
       },
       fetchFn: async (searchFields) => {
         if (this.form.get('collectionId')?.value) {
-          this.loadal.show();
+          this.activitiesLoading = true;
           try {
             const result = await this.activityService.getActivitiesByCollectionId(
               searchFields.collectionId
@@ -269,7 +266,7 @@ export class FacilityFormComponent extends EntityFormBaseComponent implements On
           } catch (error) {
             console.error('Error loading activities:', error);
           } finally {
-            this.loadal.hide();
+            this.activitiesLoading = false;
           }
         }
       },

--- a/src/app/inventory/geozone/geozone-form/geozone-form.component.html
+++ b/src/app/inventory/geozone/geozone-form/geozone-form.component.html
@@ -1,4 +1,3 @@
-<app-loadal #loadal></app-loadal>
 
 <section #collectionIdSection>
   <div class="d-flex flex-column align-items-center justify-content-center my-5">

--- a/src/app/inventory/geozone/geozone-form/geozone-form.component.ts
+++ b/src/app/inventory/geozone/geozone-form/geozone-form.component.ts
@@ -4,7 +4,6 @@ import { GeozoneService } from '../../../services/geozone.service';
 import { LoadingService } from '../../../services/loading.service';
 import { ActivatedRoute, Router } from '@angular/router';
 import { MapComponent } from '../../../map/map.component';
-import { LoadalComponent } from '../../../shared/components/loadal/loadal.component';
 import { NgdsFormsModule } from '@digitalspace/ngds-forms';
 import { CommonModule } from '@angular/common';
 import { Constants } from '../../../app.constants';
@@ -13,13 +12,12 @@ import { CollectionSelectorComponent } from '../../../shared/components/collecti
 
 @Component({
   selector: 'app-geozone-form',
-  imports: [MapComponent, LoadalComponent, NgdsFormsModule, CommonModule, SearchTermsComponent, CollectionSelectorComponent],
+  imports: [MapComponent, NgdsFormsModule, CommonModule, SearchTermsComponent, CollectionSelectorComponent],
   templateUrl: './geozone-form.component.html',
   styleUrl: './geozone-form.component.scss'
 })
 export class GeozoneFormComponent implements OnInit, AfterViewInit, AfterViewChecked {
   @ViewChild('mapComponent', { static: true }) mapComponent!: MapComponent;
-  @ViewChild('loadal', { static: true }) loadal!: LoadalComponent;
   @ViewChild('searchTerms', { static: false }) searchTermsComponent!: SearchTermsComponent;
 
   @Output() formValue: EventEmitter<any> = new EventEmitter<any>();

--- a/src/app/inventory/product/product-edit/product-edit.component.html
+++ b/src/app/inventory/product/product-edit/product-edit.component.html
@@ -1,4 +1,3 @@
-<app-loadal #loadal></app-loadal>
 <app-product-form [isEditing]="true" (formValue)="updateProductForm($event)">
 </app-product-form>
 <div class="row d-flex justify-content-end">
@@ -18,8 +17,9 @@
       <button
         class="btn btn-primary rounded-1"
         (click)="submit()"
-        [disabled]="!productForm?.valid || !productForm?.dirty">
-        Save
+        [disabled]="!productForm?.valid || !productForm?.dirty || isSubmitting">
+        <i *ngIf="isSubmitting" class="fa fa-spinner fa-spin me-2"></i>
+        {{ isSubmitting ? 'Saving...' : 'Save' }}
       </button>
     </div>
   </div>

--- a/src/app/inventory/product/product-edit/product-edit.component.ts
+++ b/src/app/inventory/product/product-edit/product-edit.component.ts
@@ -4,20 +4,20 @@ import { ProductService } from '../../../services/product.service';
 import { RelationshipService } from '../../../services/relationship.service';
 import { ActivatedRoute, Router } from '@angular/router';
 import { EntityEditBaseComponent } from '../../../shared/components/entity/entity-base/entity-edit-base.component';
-import { LoadalComponent } from '../../../shared/components/loadal/loadal.component';
+import { NgIf } from '@angular/common';
 
 @Component({
   selector: 'app-product-edit',
-  imports: [ProductFormComponent, LoadalComponent],
+  imports: [ProductFormComponent, NgIf],
   templateUrl: './product-edit.component.html',
   styleUrl: './product-edit.component.scss'
 })
 export class ProductEditComponent extends EntityEditBaseComponent implements AfterViewChecked {
   @ViewChild(ProductFormComponent) productFormComponent!: ProductFormComponent;
-  @ViewChild('loadal', { static: true }) loadal!: LoadalComponent;
 
   public productForm;
   public product;
+  public isSubmitting = false;
 
   constructor(
     protected productService: ProductService,
@@ -51,7 +51,7 @@ export class ProductEditComponent extends EntityEditBaseComponent implements Aft
       return;
     }
 
-    this.loadal.show();
+    this.isSubmitting = true;
     try {
       const props = this.formatFormForSubmission();
 
@@ -68,7 +68,7 @@ export class ProductEditComponent extends EntityEditBaseComponent implements Aft
     } catch (error) {
       console.error('Error updating product:', error);
     } finally {
-      this.loadal.hide();
+      this.isSubmitting = false;
     }
   }
 

--- a/src/app/inventory/product/product-form/product-form.component.html
+++ b/src/app/inventory/product/product-form/product-form.component.html
@@ -1,4 +1,3 @@
-<app-loadal #loadal></app-loadal>
 <section class="container pt-3 pb-3">
   <div class="row">
     <div class="col-12">
@@ -20,8 +19,9 @@
                   [control]="form.get('activity')"
                   [selectionListItems]="availableActivities"
                   [label]="'Activity'"
-                  [placeholder]="'Select an activity'"
+                  [placeholder]="loadingActivities ? 'Loading activities...' : 'Select an activity'"
                   [resetButton]="true"
+                  [disabled]="!!loadingActivities"
                 >
                 </ngds-typeahead-input>
               </div>
@@ -187,7 +187,11 @@
           <hr class="mt-4">
           <div *ngIf="!isCreating">
             <h3 class="mb-4 mt-4">Activity</h3>
-            <div class="row">
+            <div *ngIf="loadingActivities" class="text-center my-3">
+              <i class="fa fa-spinner fa-spin me-2"></i>
+              Loading activity...
+            </div>
+            <div class="row" *ngIf="!loadingActivities">
               <app-activity-list-item
               [activity]="relatedActivity"
               ></app-activity-list-item>
@@ -197,7 +201,11 @@
           <hr>
           <h3 class="mb-4 mt-4">Policies</h3>
           <p class="small mt-2">Polices are rules defining how the <strong>product</strong> behaves. They control the booking's stock, party limit, changes/cancellations, and fees. </p>
-          <div class="row">
+          <div *ngIf="loadingPolicies" class="text-center my-3">
+            <i class="fa fa-spinner fa-spin me-2"></i>
+            Loading policies...
+          </div>
+          <div class="row" *ngIf="!loadingPolicies">
             <div class="col-12 col-lg-6">
               <div class="d-flex flex-column flex-sm-row align-items-stretch align-items-sm-center gap-2 mb-4">
                 <div class="flex-grow-1">

--- a/src/app/inventory/product/product-form/product-form.component.ts
+++ b/src/app/inventory/product/product-form/product-form.component.ts
@@ -2,7 +2,6 @@ import { ChangeDetectorRef, Component, EventEmitter, Output, Input, OnInit, View
 import { Constants } from '../../../app.constants';
 import { ActivatedRoute } from '@angular/router';
 import { FormBuilder, Validators, AbstractControl, UntypedFormGroup, ReactiveFormsModule } from '@angular/forms';
-import { LoadalComponent } from '../../../shared/components/loadal/loadal.component';
 import { NgdsFormsModule } from '@digitalspace/ngds-forms';
 import { CommonModule } from '@angular/common';
 import { SearchTermsComponent } from '../../../shared/components/search-terms/search-terms.component';
@@ -23,7 +22,6 @@ import { CollectionSelectorComponent } from '../../../shared/components/collecti
     CollectionSelectorComponent,
     ActivityListItemComponent,
     PolicyListItemComponent,
-    LoadalComponent,
     PermissionDirective
   ],
   templateUrl: './product-form.component.html',
@@ -33,7 +31,6 @@ export class ProductFormComponent implements OnInit {
   @Input() isEditing: boolean = false;
   @Input() isCreating: boolean = false;
   @Output() formValue: EventEmitter<any> = new EventEmitter<any>();
-  @ViewChild('loadal', { static: true }) loadal!: LoadalComponent;
   @ViewChild('searchTerms', { static: false }) searchTermsComponent!: SearchTermsComponent;
 
   public form;
@@ -46,6 +43,8 @@ export class ProductFormComponent implements OnInit {
   private allAvailablePolicies: any[] = [];
   public policies: { display: string, value: any }[] = [];
   public relatedActivity: any[] = [];
+  public loadingActivities = false;
+  public loadingPolicies = false;
 
   constructor(
     protected cdr: ChangeDetectorRef,
@@ -90,9 +89,7 @@ export class ProductFormComponent implements OnInit {
       activitySubType: [this.product?.activitySubType || []],
       adminNotes: [this.product?.adminNotes || ''],
       collectionId: [this.product?.collectionId || 'bcparks_', {
-        nonNullable: true,
-        validators: [Validators.required],
-        updateOn: 'blur'
+        validators: [Validators.required]
       }],
       displayName: [this.product?.displayName || 'New Product', {
         nonNullable: true,
@@ -164,7 +161,7 @@ export class ProductFormComponent implements OnInit {
       return;
     }
 
-    this.loadal.show();
+    this.loadingActivities = true;
     try {
       const activities = await this.activityService.getActivitiesByCollectionId(collectionId);
       const activityItems = Array.isArray(activities?.items)
@@ -181,9 +178,9 @@ export class ProductFormComponent implements OnInit {
         value: a
       }));
 
-      // Reset activity selection when collectionId changes
-      for (const controlName of ['activity', 'activityType', 'activityId', 'activitySubType']) {
-        const value = controlName === 'activitySubType' ? [] : controlName === 'activity' ? null : '';
+      this.form.get('activity')?.reset(null, { emitEvent: false });
+      for (const controlName of ['activityType', 'activityId', 'activitySubType']) {
+        const value = controlName === 'activitySubType' ? [] : '';
         this.form.get(controlName)?.setValue(value, { emitEvent: false });
         this.form.get(controlName)?.markAsDirty();
       }
@@ -192,7 +189,10 @@ export class ProductFormComponent implements OnInit {
     } catch (error) {
       console.error('Error loading available activities:', error);
     } finally {
-      this.loadal.hide();
+      this.loadingActivities = false;
+      // Use a timeout to mark activity as untouched, to ensure after activities are loaded
+      // that the ngds-typeahead doesn't show that "this is required" (because it blurs after load)
+      setTimeout(() => this.form.get('activity')?.markAsUntouched(), 0);
     }
   }
 
@@ -202,7 +202,7 @@ export class ProductFormComponent implements OnInit {
 
   // Product already exists: load and fetch activity entities that are related to this product
   async loadActivityRelationships() {
-    this.loadal.show();
+    this.loadingActivities = true;
     try {
       const activity = await this.activityService.getActivity(this.product.collectionId, this.product.activityType, this.product.activityId);
 
@@ -218,13 +218,13 @@ export class ProductFormComponent implements OnInit {
       console.error('Error loading activity relationships:', error);
       this.relatedActivity = [];
     } finally {
-      this.loadal.hide();
+      this.loadingActivities = false;
     }
   }
 
   // Creating product: load all policies that are available (for now, these are all of our policies anyway)
   async loadAvailablePolicies() {
-    this.loadal.show();
+    this.loadingPolicies = true;
     try {
       const policies = await this.policyService.getAllPolicies();
 
@@ -242,13 +242,13 @@ export class ProductFormComponent implements OnInit {
       this.allAvailablePolicies = [];
       this.policies = [];
     } finally {
-      this.loadal.hide();
+      this.loadingPolicies = false;
     }
   }
 
   // Product already exists: load and fetch policies that are tied to this product using product pk/sk on policy GET
   async loadExistingPolicies() {
-    this.loadal.show();
+    this.loadingPolicies = true;
     try {
       const productPolicies = await this.policyService.getPoliciesByProduct(this.product.pk, this.product.sk)
 
@@ -274,7 +274,7 @@ export class ProductFormComponent implements OnInit {
       this.selectedPolicies = [];
       this.refreshPolicyOptions();
     } finally {
-      this.loadal.hide();
+      this.loadingPolicies = false;
     }
   }
 

--- a/src/app/reports/daily-passes/daily-passes-report.component.html
+++ b/src/app/reports/daily-passes/daily-passes-report.component.html
@@ -27,12 +27,11 @@
           <ngds-picklist-input
             [control]="form.get('facilityId')"
             [label]="'Facility (Optional)'"
-            [placeholder]="'All facilities'"
+            [placeholder]="facilitiesLoading ? 'Loading facilities...' : 'Select a facilty'"
             [selectionListItems]="facilityOptions"
             [resetButton]="true"
-            [disabled]="!form.get('collectionId')?.value || facilitiesLoading"
+            [disabled]="!!facilitiesLoading"
           ></ngds-picklist-input>
-          <small *ngIf="facilitiesLoading" class="text-muted">Loading facilities...</small>
         </div>
 
         <!-- Date Selection -->

--- a/src/app/shared/components/collection-selector/collection-selector.component.ts
+++ b/src/app/shared/components/collection-selector/collection-selector.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit } from '@angular/core';
+import { AfterViewChecked, ChangeDetectorRef, Component, Input, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { AbstractControl, ReactiveFormsModule } from '@angular/forms';
 import { NgdsFormsModule } from '@digitalspace/ngds-forms';
@@ -12,8 +12,8 @@ import { DataService } from '../../../services/data.service';
   templateUrl: './collection-selector.component.html',
   styleUrl: './collection-selector.component.scss'
 })
-export class CollectionSelectorComponent implements OnInit {
-  @Input() control: AbstractControl | null;
+export class CollectionSelectorComponent implements OnInit, AfterViewChecked {
+  @Input() control: AbstractControl;
   @Input() disabled = false;
   @Input() label = 'Collection';
   @Input() hint = '';
@@ -24,6 +24,7 @@ export class CollectionSelectorComponent implements OnInit {
   constructor(
     protected collectionService: CollectionService,
     protected dataService: DataService,
+    private cdr: ChangeDetectorRef
   ) { }
 
   async ngOnInit(): Promise<void> {
@@ -44,6 +45,10 @@ export class CollectionSelectorComponent implements OnInit {
       this.control?.markAsUntouched();
       this.control?.markAsPristine();
     }
+  }
+
+  ngAfterViewChecked(): void {
+    this.cdr.detectChanges()
   }
 
   setOptions(collections: any[]) {


### PR DESCRIPTION
### Ticket:

PRDT-249

### Ticket URL:

#249 

### Description:
Remove the modal overlay LoadalComponent from all inventory, admin, and
shared components. Replace with:

- `isSubmitting` flags on edit/create components with inline spinner and
  button text changes ("Saving..." / "Creating...") during async operations
- `loadingActivities` and `loadingPolicies` flags in ProductFormComponent
  to show contextual inline spinners instead of a full overlay
- `activitiesLoading` flag in FacilityFormComponent
- Font Awesome spinner (`fa fa-spinner fa-spin`) in place of Bootstrap
  `spinner-border` for loading indicators in FeatureFlagsComponent and
  CustomersComponent
- `AfterViewChecked` + `cdr.detectChanges()` added where needed to avoid
  ExpressionChangedAfterItHasBeenChecked errors

Affected components: `feature-flags`, `customers`, `activity-form`, `collection-edit/create/form`, `facility-edit`/create/form, `product-edit`/create/form, `relationship-create`, `geozone-form`, `collection-selector`
