### PR TITLE
fix: login page copy + hide sidebar when unauthenticated

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -2,7 +2,7 @@
   <app-header></app-header>
 
   <div class="main-content d-flex row me-0">
-    <div class="col-md-auto p-0">
+    <div class="col-md-auto p-0" *ngIf="authService.user()">
       <app-sidebar></app-sidebar>
       </div>
       <div class="col p-0 background-lt">

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,9 +1,10 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
 import { HeaderComponent } from './header/header.component';
 import { FooterComponent } from './footer/footer.component';
 import { CommonModule } from '@angular/common';
-import { SidebarComponent } from './shared/components/sidebar/sidebar.component'; // <-- Add this import
+import { SidebarComponent } from './shared/components/sidebar/sidebar.component';
+import { AuthService } from './services/auth.service';
 
 
 @Component({
@@ -14,4 +15,5 @@ import { SidebarComponent } from './shared/components/sidebar/sidebar.component'
 })
 export class AppComponent {
   title = 'reserve-rec-admin';
+  protected authService = inject(AuthService);
 }

--- a/src/app/login/login.component.html
+++ b/src/app/login/login.component.html
@@ -8,7 +8,7 @@
         <div class="d-flex flex-column align-items-center gap-1">
           <div class="login-btn-group">
             <button class="btn btn-primary w-100" (click)="onLogin('bcsc')">
-              Log In with BC Services Card
+              Log in with BC Services Card
             </button>
             <p class="mb-3 text-start">
               <a
@@ -16,7 +16,7 @@
                 target="_blank"
                 rel="noopener">
                 <i class="fa-regular fa-gear"></i>
-                Set up the BC Services Card App
+                Set up the BC Services Card Account
               </a>
             </p>
           </div>
@@ -38,7 +38,7 @@
 
           <div class="login-btn-group">
             <button class="btn btn-primary w-100" (click)="onLogin('idir')">
-              Log In with IDIR
+              Log in with IDIR
             </button>
           </div>
         </div>


### PR DESCRIPTION
### Ticket:

#270

### Description:

- "Log In" → "Log in" on BCSC + IDIR buttons
- "BC Services Card App" → "Account" link copy
- Hide sidebar column on login (stray blue strip)