### PR TITLE
fix(header): use AuthService.logout + clean up auth-session poll

### DIFF
--- a/src/app/header/header.component.ts
+++ b/src/app/header/header.component.ts
@@ -2,9 +2,10 @@ import { ChangeDetectorRef, Component, Input, OnDestroy, OnInit } from '@angular
 import { Subscription } from 'rxjs';
 import { ConfigService } from '../services/config.service';
 import { SidebarService } from '../services/sidebar.service';
+import { AuthService } from '../services/auth.service';
 import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
-import { signInWithRedirect, getCurrentUser, fetchAuthSession, signOut, fetchUserAttributes } from 'aws-amplify/auth';
+import { getCurrentUser, fetchAuthSession, fetchUserAttributes } from 'aws-amplify/auth';
 import { Router } from '@angular/router';
 
 @Component({
@@ -25,12 +26,15 @@ export class HeaderComponent implements OnInit, OnDestroy {
   public welcomeMsg: string;
   public isAuthorized: boolean;
   public routes: any[] = [];
+  private sessionPollId: ReturnType<typeof setInterval> | null = null;
+  private destroyed = false;
 
   constructor(
     protected configService: ConfigService,
     protected sidebarService: SidebarService,
     private changeDetectorRef: ChangeDetectorRef,
     private router: Router,
+    private authService: AuthService,
   ) {
     this.subscriptions.add(
       sidebarService.routes.subscribe((routes) => {
@@ -53,24 +57,42 @@ export class HeaderComponent implements OnInit, OnDestroy {
       console.log(e);
     }
 
-    // Change this to a back-end service.
-    setInterval(async () => {
-      this.session = await fetchAuthSession();
-      if (this?.session?.tokens?.idToken?.payload != null) {
-        this.isAuthenticed = true;
-      } else {
+    // Poll the auth session every 15s to refresh the "logged in?" badge.
+    // The interval id is tracked so ngOnDestroy can clear it — without that
+    // the poll keeps firing after the component leaves, including during
+    // logout, racing the sign-out and producing the visible console/network
+    // errors reported in #269.
+    this.sessionPollId = setInterval(async () => {
+      if (this.destroyed) return;
+      try {
+        this.session = await fetchAuthSession();
+        if (this.destroyed) return;
+        this.isAuthenticed = !!this?.session?.tokens?.idToken?.payload;
+        this.changeDetectorRef.detectChanges();
+      } catch (e) {
+        // Expected mid-logout — session is being torn down. Don't surface as
+        // an error to the user; just stop polling until next mount.
         this.isAuthenticed = false;
       }
-      this.changeDetectorRef.detectChanges();
     }, 15000);
   }
 
   public async onLoginLogoutClick(inOrOut: string) {
-    
     if (inOrOut === 'login') {
       this.router.navigate(['/login']);
-    } else {
-      signOut();
+      return;
+    }
+    // Stop the auth-session poll first so it can't race the sign-out and
+    // log network errors to the console. Then delegate to AuthService.logout
+    // which awaits Amplify signOut + clears the user/session signals.
+    if (this.sessionPollId) {
+      clearInterval(this.sessionPollId);
+      this.sessionPollId = null;
+    }
+    try {
+      await this.authService.logout();
+    } catch (err) {
+      console.error('Logout failed:', err);
     }
   }
 
@@ -83,6 +105,11 @@ export class HeaderComponent implements OnInit, OnDestroy {
     }
   }
   ngOnDestroy() {
+    this.destroyed = true;
+    if (this.sessionPollId) {
+      clearInterval(this.sessionPollId);
+      this.sessionPollId = null;
+    }
     this.subscriptions.unsubscribe();
   }
 }


### PR DESCRIPTION
### Ticket:

#269

### Description:

- The logout click called bare \`signOut()\` from \`aws-amplify/auth\` without awaiting it, and a 15s \`setInterval\` polling \`fetchAuthSession()\` kept firing during sign-out — the poll raced the token teardown and surfaced console + network errors before the user actually got logged out.
- Switched the click handler to \`AuthService.logout()\` (already exists, awaits Amplify signOut + clears the user/session signals + permissions).
- Tracked the poll interval id and clear it on logout-click + \`ngOnDestroy\` so it can no longer outlive the component.
- Swallowed expected errors inside the poll body (session being torn down) so they don't reach the console as red errors.

Ref #269