### PR TITLE
fix(inventory): destroy router-outlet child when going back to /create

### DIFF
--- a/src/app/inventory/create-inventory/create-inventory.component.html
+++ b/src/app/inventory/create-inventory/create-inventory.component.html
@@ -80,4 +80,8 @@
     <hr/>
   </div>
 </section>
-<router-outlet></router-outlet>
+<!-- *ngIf on the outlet itself ensures a previously-mounted child is fully
+     destroyed when the URL goes back to /inventory/create (no child), and
+     a fresh outlet is created when a new child slug is picked. Defends
+     against the stale-child rendering described in #189. -->
+<router-outlet *ngIf="!showSelectionOptions()"></router-outlet>

--- a/src/app/inventory/create-inventory/create-inventory.component.ts
+++ b/src/app/inventory/create-inventory/create-inventory.component.ts
@@ -1,5 +1,6 @@
-import { Component } from '@angular/core';
-import { Router, RouterOutlet } from '@angular/router';
+import { Component, OnDestroy } from '@angular/core';
+import { NavigationEnd, Router, RouterOutlet } from '@angular/router';
+import { Subscription, filter } from 'rxjs';
 import { CreateInventorySelectorComponent } from './create-inventory-selector/create-inventory-selector.component';
 import { CommonModule } from '@angular/common';
 import { PermissionDirective } from '../../shared/directives/permission.directive';
@@ -11,33 +12,45 @@ import { BreadcrumbComponent, BreadcrumbItem } from '../../shared/components/bre
   templateUrl: './create-inventory.component.html',
   styleUrl: './create-inventory.component.scss'
 })
-export class CreateInventoryComponent {
+export class CreateInventoryComponent implements OnDestroy {
+  // Driven by NavigationEnd events so the template re-evaluates on every
+  // completed route change — including browser back/forward. Reading
+  // `router.url` from getters in the template was unreliable under zone
+  // event-coalescing: after a back-then-sibling-link navigation the
+  // previously-mounted child sometimes lingered (see #189).
+  public childSlug: string | null = null;
+  private routerSub: Subscription;
+
   get breadcrumbs(): BreadcrumbItem[] {
     const items: BreadcrumbItem[] = [
       { label: 'Inventory', link: ['/inventory'] },
-      { label: 'Create', link: this.activeChildLabel() ? ['/inventory/create'] : undefined },
+      { label: 'Create', link: this.childSlug ? ['/inventory/create'] : undefined },
     ];
-    const child = this.activeChildLabel();
-    if (child) items.push({ label: child });
+    if (this.childSlug) {
+      items.push({ label: this.childSlug.charAt(0).toUpperCase() + this.childSlug.slice(1) });
+    }
     return items;
   }
 
-  private activeChildLabel(): string | null {
-    const parts = this.router.url.split('?')[0].split('/').filter(Boolean);
-    // /inventory/create -> ['inventory', 'create'], no child
-    // /inventory/create/collection -> ['inventory', 'create', 'collection']
-    const childSlug = parts[2];
-    if (!childSlug) return null;
-    return childSlug.charAt(0).toUpperCase() + childSlug.slice(1);
+  constructor(protected router: Router) {
+    this.updateChildSlug(this.router.url);
+    this.routerSub = this.router.events
+      .pipe(filter((e): e is NavigationEnd => e instanceof NavigationEnd))
+      .subscribe((e) => this.updateChildSlug(e.urlAfterRedirects));
   }
 
-  constructor(protected router: Router) {}
+  ngOnDestroy(): void {
+    this.routerSub?.unsubscribe();
+  }
+
+  private updateChildSlug(url: string): void {
+    const parts = url.split('?')[0].split('/').filter(Boolean);
+    // /inventory/create        -> ['inventory', 'create'], no child
+    // /inventory/create/<slug> -> ['inventory', 'create', '<slug>']
+    this.childSlug = parts[2] ?? null;
+  }
 
   showSelectionOptions(): boolean {
-    const urlParts = this.router.url.split('/');
-    if (urlParts[urlParts.length-1] === 'create') {
-      return true;
-    }
-    return false;
+    return this.childSlug === null;
   }
 }


### PR DESCRIPTION
### Ticket:

#189

### Description:

- QA send-back: the previous fix (#246) removed an \`ngAfterViewChecked\` \`detectChanges()\` workaround but the symptom is back on TEST. With zone event-coalescing, reading \`router.url\` from template getters on every CD pass was sometimes stale, so the \`<router-outlet>\`'s previously-mounted child lingered after a back-then-sibling-link navigation.
- Track the active child slug from \`NavigationEnd\` events instead of polling \`router.url\` from getters, so the template re-evaluates only on completed route changes.
- Gate the \`<router-outlet>\` on \`*ngIf="!showSelectionOptions()"\` so the outlet (and its child) is fully destroyed when the URL goes back to \`/inventory/create\` and recreated cleanly when a new child slug is picked.

Ref #189