### PR TITLE
fix(inventory): remove ngAfterViewChecked detectChanges anti-pattern

### DIFF
--- a/src/app/admin/feature-flags/feature-flags.component.ts
+++ b/src/app/admin/feature-flags/feature-flags.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewChecked, ChangeDetectorRef, Component, OnDestroy, OnInit } from '@angular/core';
+import { ChangeDetectorRef, Component, OnDestroy, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule, ReactiveFormsModule, UntypedFormGroup, UntypedFormControl } from '@angular/forms';
 import { BsModalService } from 'ngx-bootstrap/modal';
@@ -23,7 +23,7 @@ interface FlagDefinition {
   templateUrl: './feature-flags.component.html',
   styleUrls: ['./feature-flags.component.scss']
 })
-export class FeatureFlagsComponent implements OnInit, AfterViewChecked, OnDestroy {
+export class FeatureFlagsComponent implements OnInit, OnDestroy {
   loading = true;
   saving = false;
 
@@ -51,10 +51,6 @@ export class FeatureFlagsComponent implements OnInit, AfterViewChecked, OnDestro
   async ngOnInit(): Promise<void> {
     await this.loadFlags();
     this.loading = false;
-  }
-
-  ngAfterViewChecked(): void {
-    this.cdr.detectChanges()
   }
 
   async loadFlags(): Promise<void> {

--- a/src/app/customers/customers.component.ts
+++ b/src/app/customers/customers.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewChecked, ChangeDetectorRef, Component, OnInit } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { Router } from '@angular/router';
@@ -12,7 +12,7 @@ import { LoadingService } from '../services/loading.service';
   templateUrl: './customers.component.html',
   styleUrl: './customers.component.scss'
 })
-export class CustomersComponent implements OnInit, AfterViewChecked {
+export class CustomersComponent implements OnInit {
   customers: any[] = [];
   currentOffset = 0;
   pageSize = 20;
@@ -42,17 +42,10 @@ export class CustomersComponent implements OnInit, AfterViewChecked {
     private customerService: CustomerService,
     private logger: LoggerService,
     private loadingService: LoadingService,
-    private cdr: ChangeDetectorRef
   ) {}
 
   async ngOnInit() {
     await this.loadCustomers();
-  }
-
-  ngAfterViewChecked(): void {
-    //Called after every check of the component's view. Applies to components only.
-    //Add 'implements AfterViewChecked' to the class.
-    this.cdr.detectChanges()
   }
 
   async loadCustomers(append = false) {

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewChecked, ChangeDetectorRef, Component, OnDestroy, OnInit } from '@angular/core';
+import { ChangeDetectorRef, Component, OnDestroy, OnInit } from '@angular/core';
 import { AuthService } from '../services/auth.service';
 import { Router } from '@angular/router';
 import { CommonModule } from '@angular/common';
@@ -17,7 +17,7 @@ import { LoginComponent } from '../login/login.component';
 
   styleUrl: './home.component.scss'
 })
-export class HomeComponent implements OnInit, AfterViewChecked, OnDestroy {
+export class HomeComponent implements OnInit, OnDestroy {
   isAuthenticed = false;
   isAdmin = false;
   checkingSession = true;
@@ -34,10 +34,6 @@ export class HomeComponent implements OnInit, AfterViewChecked, OnDestroy {
     } finally {
       this.checkingSession = false;
     }
-  }
-
-  ngAfterViewChecked(): void {
-    this.cdr.detectChanges()
   }
 
   goToLogin() {

--- a/src/app/inventory/activity/activity-form/activity-form.component.ts
+++ b/src/app/inventory/activity/activity-form/activity-form.component.ts
@@ -3,7 +3,6 @@ import {
   Component,
   OnInit,
   ViewChild,
-  AfterViewChecked,
   Output,
   EventEmitter
 } from '@angular/core';
@@ -22,7 +21,7 @@ import { CollectionSelectorComponent } from '../../../shared/components/collecti
   templateUrl: './activity-form.component.html',
   styleUrls: ['./activity-form.component.scss']
 })
-export class ActivityFormComponent implements OnInit, AfterViewChecked {
+export class ActivityFormComponent implements OnInit {
   @ViewChild('searchTerms', { static: false }) searchTermsComponent!: SearchTermsComponent;
 
   @Output() formValue: EventEmitter<any> = new EventEmitter<any>();
@@ -116,10 +115,6 @@ export class ActivityFormComponent implements OnInit, AfterViewChecked {
       pk: entity.pk,
       sk: entity.sk
     }));
-  }
-
-  ngAfterViewChecked(): void {
-    this.cdr.detectChanges()
   }
 
   // Update filtered activity sub types when activity type changes

--- a/src/app/inventory/collection/collection-edit/collection-edit.component.ts
+++ b/src/app/inventory/collection/collection-edit/collection-edit.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewChecked, ChangeDetectorRef, Component, ViewChild } from '@angular/core';
+import { ChangeDetectorRef, Component, ViewChild } from '@angular/core';
 import { CollectionFormComponent } from '../collection-form/collection-form.component';
 import { CollectionService } from '../../../services/collection.service';
 import { RelationshipService } from '../../../services/relationship.service';
@@ -12,7 +12,7 @@ import { NgIf } from '@angular/common';
   templateUrl: './collection-edit.component.html',
   styleUrl: './collection-edit.component.scss'
 })
-export class CollectionEditComponent extends EntityEditBaseComponent implements AfterViewChecked {
+export class CollectionEditComponent extends EntityEditBaseComponent {
   @ViewChild(CollectionFormComponent) collectionFormComponent!: CollectionFormComponent;
 
   public collectionForm;
@@ -30,10 +30,6 @@ export class CollectionEditComponent extends EntityEditBaseComponent implements 
     if (this.route.parent?.snapshot.data['collection']) {
       this.collection = this.route.parent?.snapshot.data['collection'];
     }
-  }
-
-  ngAfterViewChecked(): void {
-    this.cdr.detectChanges();
   }
 
   updateCollectionForm(event) {

--- a/src/app/inventory/collection/collection-form/collection-form.component.ts
+++ b/src/app/inventory/collection/collection-form/collection-form.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewChecked, ChangeDetectorRef, Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { ChangeDetectorRef, Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { AbstractControl, ReactiveFormsModule, UntypedFormBuilder, UntypedFormGroup, Validators } from '@angular/forms';
 import { NgdsFormsModule } from '@digitalspace/ngds-forms';
@@ -14,7 +14,7 @@ import { PermissionDirective } from '../../../shared/directives/permission.direc
   templateUrl: './collection-form.component.html',
   styleUrl: './collection-form.component.scss'
 })
-export class CollectionFormComponent implements OnInit, AfterViewChecked {
+export class CollectionFormComponent implements OnInit {
   @Input() collection: any = null;
   @Input() isCreating: boolean = false;
   @Output() formValue = new EventEmitter<UntypedFormGroup>();
@@ -38,10 +38,6 @@ export class CollectionFormComponent implements OnInit, AfterViewChecked {
       this.formValue.emit(this.form);
     });
     this.formValue.emit(this.form);
-  }
-
-  ngAfterViewChecked() {
-    this.cdr.detectChanges();
   }
 
   buildForm() {

--- a/src/app/inventory/create-inventory/collection-create/collection-create.component.ts
+++ b/src/app/inventory/create-inventory/collection-create/collection-create.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewChecked, ChangeDetectorRef, Component } from '@angular/core';
+import { Component } from '@angular/core';
 import { Router } from '@angular/router';
 import { CollectionService } from '../../../services/collection.service';
 import { CollectionFormComponent } from '../../collection/collection-form/collection-form.component';
@@ -12,7 +12,7 @@ import { NgIf } from '@angular/common';
   templateUrl: './collection-create.component.html',
   styleUrl: './collection-create.component.scss'
 })
-export class CollectionCreateComponent implements AfterViewChecked {
+export class CollectionCreateComponent {
   public collectionForm: UntypedFormGroup;
   public collection;
   public isSubmitting = false;
@@ -21,12 +21,7 @@ export class CollectionCreateComponent implements AfterViewChecked {
     protected collectionService: CollectionService,
     protected router: Router,
     protected toastService: ToastService,
-    private cdr: ChangeDetectorRef
   ) { }
-
-  ngAfterViewChecked(): void {
-    this.cdr.detectChanges()
-  }
 
   updateCollectionForm(event) {
     this.collectionForm = event;

--- a/src/app/inventory/create-inventory/policy-create/policy-create-selector/policy-create-selector.component.ts
+++ b/src/app/inventory/create-inventory/policy-create/policy-create-selector/policy-create-selector.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewChecked, ChangeDetectorRef, Component } from '@angular/core';
+import { Component } from '@angular/core';
 import { Router, RouterOutlet } from '@angular/router';
 import { CreateInventorySelectorComponent } from '../../create-inventory-selector/create-inventory-selector.component';
 import { CommonModule } from '@angular/common';
@@ -10,18 +10,11 @@ import { Constants } from '../../../../app.constants';
   templateUrl: './policy-create-selector.component.html',
   styleUrl: './policy-create-selector.component.scss'
 })
-export class PolicyCreateSelectorComponent implements AfterViewChecked {
+export class PolicyCreateSelectorComponent {
 
   constructor(
     protected router: Router,
-    protected cdr: ChangeDetectorRef
   ) { }
-
-  ngAfterViewChecked(): void {
-    // This is a workaround to ensure that the router outlet is updated after the view is checked
-    // This is necessary because the router outlet may not update immediately after navigation
-    this.cdr.detectChanges();
-  }
 
   showSelectionOptions(): boolean {
     const urlParts = this.router.url.split('/');

--- a/src/app/inventory/create-inventory/relationship-create/relationship-create.component.ts
+++ b/src/app/inventory/create-inventory/relationship-create/relationship-create.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ChangeDetectorRef, effect, signal, untracked, input, AfterViewChecked } from '@angular/core';
+import { Component, OnInit, ChangeDetectorRef, effect, signal, untracked, input } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { UntypedFormControl, UntypedFormGroup, Validators } from '@angular/forms';
 import { Router, ActivatedRoute } from '@angular/router';
@@ -18,7 +18,7 @@ import { Constants } from '../../../app.constants';
   templateUrl: './relationship-create.component.html',
   styleUrls: ['./relationship-create.component.scss']
 })
-export class RelationshipCreateComponent implements AfterViewChecked {
+export class RelationshipCreateComponent {
   public form: UntypedFormGroup;
 
   // Use signals to track and subscribe to changes
@@ -138,10 +138,6 @@ export class RelationshipCreateComponent implements AfterViewChecked {
         });
       }
     });
-  }
-
-  ngAfterViewChecked(): void {
-    this.cdr.detectChanges()      
   }
 
   initializeForm() {

--- a/src/app/inventory/facility/facility-edit/facility-edit.component.ts
+++ b/src/app/inventory/facility/facility-edit/facility-edit.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewChecked, ChangeDetectorRef, Component, ViewChild } from '@angular/core';
+import { ChangeDetectorRef, Component, ViewChild } from '@angular/core';
 import { FacilityFormComponent } from '../facility-form/facility-form.component';
 import { FacilityService } from '../../../services/facility.service';
 import { RelationshipService } from '../../../services/relationship.service';
@@ -12,7 +12,7 @@ import { NgIf } from '@angular/common';
   templateUrl: './facility-edit.component.html',
   styleUrl: './facility-edit.component.scss'
 })
-export class FacilityEditComponent extends EntityEditBaseComponent implements AfterViewChecked {
+export class FacilityEditComponent extends EntityEditBaseComponent {
   @ViewChild(FacilityFormComponent) facilityFormComponent!: FacilityFormComponent;
 
   public facilityForm;
@@ -30,10 +30,6 @@ export class FacilityEditComponent extends EntityEditBaseComponent implements Af
     if (this.route.parent?.snapshot.data['facility']) {
       this.facility = this.route.parent?.snapshot.data['facility'];
     }
-  }
-
-  ngAfterViewChecked(): void {
-    this.cdr.detectChanges();
   }
 
   updateFacilityForm(event) {

--- a/src/app/inventory/facility/facility-form/facility-form.component.ts
+++ b/src/app/inventory/facility/facility-form/facility-form.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewChecked, ChangeDetectorRef, Component, effect, EventEmitter, Input, OnInit, Output, signal, TemplateRef, ViewChild, WritableSignal } from '@angular/core';
+import { ChangeDetectorRef, Component, effect, EventEmitter, Input, OnInit, Output, signal, TemplateRef, ViewChild, WritableSignal } from '@angular/core';
 import { MapComponent } from '../../../map/map.component';
 import { Constants } from '../../../app.constants';
 import { LoadingService } from '../../../services/loading.service';
@@ -33,7 +33,7 @@ import { PermissionDirective } from '../../../shared/directives/permission.direc
   templateUrl: './facility-form.component.html',
   styleUrl: './facility-form.component.scss'
 })
-export class FacilityFormComponent extends EntityFormBaseComponent implements OnInit, AfterViewChecked {
+export class FacilityFormComponent extends EntityFormBaseComponent implements OnInit {
   @ViewChild('mapComponent', { static: true }) mapComponent!: MapComponent;
   @ViewChild('searchTerms', { static: false }) searchTermsComponent!: SearchTermsComponent;
 
@@ -175,10 +175,6 @@ export class FacilityFormComponent extends EntityFormBaseComponent implements On
         this.mapComponent?.updateMap();
       }
     });
-  }
-
-  ngAfterViewChecked() {
-    this.cdr.detectChanges();
   }
 
   updateLocationMarkers() {

--- a/src/app/inventory/geozone/geozone-form/geozone-form.component.ts
+++ b/src/app/inventory/geozone/geozone-form/geozone-form.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewChecked, AfterViewInit, ChangeDetectorRef, Component, effect, EventEmitter, OnInit, Output, signal, ViewChild, WritableSignal } from '@angular/core';
+import { AfterViewInit, ChangeDetectorRef, Component, effect, EventEmitter, OnInit, Output, signal, ViewChild, WritableSignal } from '@angular/core';
 import { UntypedFormControl, UntypedFormGroup, Validators } from '@angular/forms';
 import { GeozoneService } from '../../../services/geozone.service';
 import { LoadingService } from '../../../services/loading.service';
@@ -16,7 +16,7 @@ import { CollectionSelectorComponent } from '../../../shared/components/collecti
   templateUrl: './geozone-form.component.html',
   styleUrl: './geozone-form.component.scss'
 })
-export class GeozoneFormComponent implements OnInit, AfterViewInit, AfterViewChecked {
+export class GeozoneFormComponent implements OnInit, AfterViewInit {
   @ViewChild('mapComponent', { static: true }) mapComponent!: MapComponent;
   @ViewChild('searchTerms', { static: false }) searchTermsComponent!: SearchTermsComponent;
 
@@ -119,10 +119,6 @@ export class GeozoneFormComponent implements OnInit, AfterViewInit, AfterViewChe
         this.mapComponent?.updateMap();
       }
     });
-  }
-
-  ngAfterViewChecked(): void {
-    this.cdr.detectChanges()
   }
 
   private initializeForm() {

--- a/src/app/inventory/inventory-search/inventory-search.component.ts
+++ b/src/app/inventory/inventory-search/inventory-search.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewChecked, ChangeDetectorRef, Component, ContentChildren, effect, ElementRef, OnChanges, OnDestroy, OnInit, signal, SimpleChanges, ViewChild, ViewContainerRef, WritableSignal } from '@angular/core';
+import { ChangeDetectorRef, Component, ContentChildren, effect, ElementRef, OnChanges, OnDestroy, OnInit, signal, SimpleChanges, ViewChild, ViewContainerRef, WritableSignal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { UntypedFormControl, UntypedFormGroup } from '@angular/forms';
 import { NgdsFormsModule } from '@digitalspace/ngds-forms';
@@ -16,7 +16,7 @@ import { MapMarkerComponent } from './map-marker/map-marker.component';
   templateUrl: './inventory-search.component.html',
   styleUrl: './inventory-search.component.scss'
 })
-export class InventorySearchComponent implements OnInit, AfterViewChecked, OnDestroy {
+export class InventorySearchComponent implements OnInit, OnDestroy {
   @ViewChild('mapComponent') mapComponent!: MapComponent;
   @ViewChild('markerRenderZone', { read: ViewContainerRef }) vcr!: ViewContainerRef;
   @ViewChild('searchOverlay') searchOverlay!: ElementRef; // Adjust type as necessary
@@ -194,12 +194,6 @@ export class InventorySearchComponent implements OnInit, AfterViewChecked, OnDes
       element: await this.generateMapMarkerHTML(options, data)
     };
     return markerOptions;
-  }
-
-  ngAfterViewChecked(): void {
-    // This is a workaround to ensure change detection runs after the view has been checked.
-    // Missing this check seems to be a by-product of lazy loading.
-    this.cdr.detectChanges();
   }
 
   resetFilters(schemaChange = false) {

--- a/src/app/inventory/product/product-edit/product-edit.component.ts
+++ b/src/app/inventory/product/product-edit/product-edit.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewChecked, ChangeDetectorRef, Component, ViewChild } from '@angular/core';
+import { ChangeDetectorRef, Component, ViewChild } from '@angular/core';
 import { ProductFormComponent } from '../product-form/product-form.component';
 import { ProductService } from '../../../services/product.service';
 import { RelationshipService } from '../../../services/relationship.service';
@@ -12,7 +12,7 @@ import { NgIf } from '@angular/common';
   templateUrl: './product-edit.component.html',
   styleUrl: './product-edit.component.scss'
 })
-export class ProductEditComponent extends EntityEditBaseComponent implements AfterViewChecked {
+export class ProductEditComponent extends EntityEditBaseComponent {
   @ViewChild(ProductFormComponent) productFormComponent!: ProductFormComponent;
 
   public productForm;
@@ -30,10 +30,6 @@ export class ProductEditComponent extends EntityEditBaseComponent implements Aft
     if (this.route.parent?.snapshot.data['product']) {
       this.product = this.route.parent?.snapshot.data['product'];
     }
-  }
-
-  ngAfterViewChecked(): void {
-    this.cdr.detectChanges();
   }
 
   updateProductForm(event) {

--- a/src/app/inventory/search-results-table/search-results-table.component.ts
+++ b/src/app/inventory/search-results-table/search-results-table.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewChecked, AfterViewInit, ChangeDetectorRef, Component, ElementRef, Input, ViewChild, WritableSignal, effect, signal } from '@angular/core';
+import { AfterViewInit, ChangeDetectorRef, Component, ElementRef, Input, ViewChild, WritableSignal, effect, signal } from '@angular/core';
 import { DataService } from '../../services/data.service';
 import { Subscription } from 'rxjs';
 import { Constants } from '../../app.constants';

--- a/src/app/reports/daily-passes/daily-passes-report.component.ts
+++ b/src/app/reports/daily-passes/daily-passes-report.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewChecked, ChangeDetectorRef, Component, OnDestroy, OnInit } from '@angular/core';
+import { ChangeDetectorRef, Component, OnDestroy, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ReactiveFormsModule, FormBuilder, Validators } from '@angular/forms';
 import { NgdsFormsModule } from '@digitalspace/ngds-forms';
@@ -37,7 +37,7 @@ interface DailyPassRecord {
   templateUrl: './daily-passes-report.component.html',
   styleUrl: './daily-passes-report.component.scss'
 })
-export class DailyPassesReportComponent implements OnInit, AfterViewChecked, OnDestroy {
+export class DailyPassesReportComponent implements OnInit, OnDestroy {
   form = this.fb.group({
     collectionId: this.fb.control('', { nonNullable: true, validators: [Validators.required], updateOn: 'blur' }),
     facilityId: [''],
@@ -77,10 +77,6 @@ export class DailyPassesReportComponent implements OnInit, AfterViewChecked, OnD
       this.facilityOptions = [];
       this.onCollectionIdChange();
     });
-  }
-
-  ngAfterViewChecked(): void {
-    this.cdr.detectChanges();
   }
 
   async loadCollections() {

--- a/src/app/shared/components/collection-selector/collection-selector.component.ts
+++ b/src/app/shared/components/collection-selector/collection-selector.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewChecked, ChangeDetectorRef, Component, Input, OnInit } from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { AbstractControl, ReactiveFormsModule } from '@angular/forms';
 import { NgdsFormsModule } from '@digitalspace/ngds-forms';
@@ -12,7 +12,7 @@ import { DataService } from '../../../services/data.service';
   templateUrl: './collection-selector.component.html',
   styleUrl: './collection-selector.component.scss'
 })
-export class CollectionSelectorComponent implements OnInit, AfterViewChecked {
+export class CollectionSelectorComponent implements OnInit {
   @Input() control: AbstractControl;
   @Input() disabled = false;
   @Input() label = 'Collection';
@@ -24,7 +24,6 @@ export class CollectionSelectorComponent implements OnInit, AfterViewChecked {
   constructor(
     protected collectionService: CollectionService,
     protected dataService: DataService,
-    private cdr: ChangeDetectorRef
   ) { }
 
   async ngOnInit(): Promise<void> {
@@ -45,10 +44,6 @@ export class CollectionSelectorComponent implements OnInit, AfterViewChecked {
       this.control?.markAsUntouched();
       this.control?.markAsPristine();
     }
-  }
-
-  ngAfterViewChecked(): void {
-    this.cdr.detectChanges()
   }
 
   setOptions(collections: any[]) {


### PR DESCRIPTION
Ticket: https://github.com/bcgov/reserve-rec-admin/issues/252

### Description:
Removed `ngAfterViewChecked() { this.cdr.detectChanges(); }` from 16 components. The forced detectChanges() inside every view check caused scroll to become unresponsive after saving a product or when viewing Activities (and starved CD generally). Same anti-pattern that produced #189; now uniformly removed.

Verified in dev: product save → scroll smooth, Activities → scroll smooth, no regressions on Customers, Daily Passes, Feature Flags, Home, Collection/Facility forms, Inventory Search.