### PR TITLE
fix(sidebar): restore user signal on page refresh

### DIFF
--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -50,6 +50,17 @@ export class AuthService {
       },
     });
     await this.setRefresh();
+    // Hub's 'signedIn' event only fires on the initial OAuth callback, not on
+    // page refresh. Without this, this.user() stays null after refresh and the
+    // sidebar (gated by *ngIf="authService.user()") disappears — #277.
+    if (this.session()?.tokens) {
+      try {
+        const userAttributes = await fetchUserAttributes();
+        this.updateUser(userAttributes);
+      } catch (error) {
+        this.loggerService.error(`Failed to load user attributes on init: ${error}`);
+      }
+    }
     this.listenToAuthEvents();
     return Promise.resolve();
   }


### PR DESCRIPTION
Ticket: https://github.com/bcgov/reserve-rec-admin/issues/277

### Description:
The `user` signal in `AuthService` was only populated by Amplify's `signedIn` Hub event, which fires once on the OAuth callback and not on subsequent page refreshes. Combined with `*ngIf="authService.user()"` on the sidebar (added in #272), this caused the sidebar to disappear whenever a logged-in user refreshed the page.

`AuthService.init()` now calls `fetchUserAttributes()` after `setRefresh()` when there's a valid session, restoring the signal so the sidebar stays visible.