### PR TITLE
fix(activity): populate sub-type options before form init

### DIFF
--- a/src/app/inventory/activity/activity-form/activity-form.component.ts
+++ b/src/app/inventory/activity/activity-form/activity-form.component.ts
@@ -46,7 +46,12 @@ export class ActivityFormComponent implements OnInit {
 
   ngOnInit() {
     this.activityTypes = this.activityTypes.filter(type => type.value !== 'noType');
-    this.activitySubTypes = [];
+
+    // Populate sub-type options BEFORE creating the form. The ngds picklist
+    // resets its bound control if the control's value isn't in the options
+    // when its @Input first binds — which wipes activitySubType on edit if
+    // we populate options after form init. See #221.
+    this.activitySubTypes = this.subTypeOptionsFor(this.activity?.activityType);
 
     this.initializeForm();
 
@@ -95,14 +100,10 @@ export class ActivityFormComponent implements OnInit {
     });
 
 
-    this.form.get('activityType').valueChanges.subscribe(() => {
-      this.updateFilteredActivitySubTypes();
+    this.form.get('activityType').valueChanges.subscribe((newType) => {
+      this.activitySubTypes = this.subTypeOptionsFor(newType);
+      this.cdr.detectChanges();
     });
-
-    // Populate the sub-type dropdown for the existing activityType when editing.
-    // Without this, the form has the activitySubType value set but the picklist
-    // has no options to display it against, so the field appears empty.
-    this.updateFilteredActivitySubTypes();
   }
 
 
@@ -117,20 +118,17 @@ export class ActivityFormComponent implements OnInit {
     }));
   }
 
-  // Update filtered activity sub types when activity type changes
-  updateFilteredActivitySubTypes() {
-    const selectedType = this.form.get('activityType')?.value;
-    if (selectedType) {
-      this.activitySubTypes = Object.entries(Constants.activityTypes[selectedType]?.subTypes || {}).map(([key, value]: [any, any]) => {
-        return {
-          display: value?.display,
-          value: value?.value
-        };
-      });
-    } else {
-      this.activitySubTypes = [];
+  // Build the sub-type options for a given activity type (used both during
+  // initial form setup and when the user changes activity type).
+  private subTypeOptionsFor(activityType: string | undefined): { display: string; value: string }[] {
+    if (!activityType) {
+      return [];
     }
-    this.cdr.detectChanges();
+    const subTypes = Constants.activityTypes[activityType]?.subTypes || {};
+    return Object.entries(subTypes).map(([, value]: [any, any]) => ({
+      display: value?.display,
+      value: value?.value,
+    }));
   }
 
   // Handle search terms updates from the component


### PR DESCRIPTION
Ticket: https://github.com/bcgov/reserve-rec-admin/issues/221

### Description:
On the activity edit page the **Activity Sub Type** field came up blank even though the saved value existed (e.g. Day Use → Vehicle Parking). PR #247 added a call to populate the sub-type options after `initializeForm()`, but that races the ngds picklist's first `@Input` binding: when the picklist sees its options list and the bound control's value isn't in it, the library calls `resetControl()` and wipes the value. By the time the populated options arrive, the control is already empty.

Fix: build the sub-type options *before* the form is created, so the picklist's very first binding pass already has matching options for the saved `activitySubType`.

Also folded the `updateFilteredActivitySubTypes()` method into a pure helper used in two places (initial setup + activityType change).