### PR TITLE
fix(inventory/create): swap form on browser back/forward

### DIFF
--- a/src/app/no-reuse-route-strategy.ts
+++ b/src/app/no-reuse-route-strategy.ts
@@ -1,21 +1,27 @@
 import { ActivatedRouteSnapshot, BaseRouteReuseStrategy } from '@angular/router';
 
-// Tweaks the default route-reuse so that switching between immediate siblings
-// under /inventory/create (e.g. /create/geozone -> /create/facility, or back to
-// the home selector at /create) forces the previous child to be destroyed.
-// The default outlet behaviour left the previous child mounted alongside the
-// new one in this specific subtree (#189, #277 follow-up). Everywhere else
-// falls back to Angular's default reuse rules so breadcrumb links and other
-// cross-subtree navigations behave normally.
+// On browser back/forward (popstate) the router-outlet under /inventory/create
+// could keep the previously-selected create form mounted instead of activating
+// the route the URL now points at — the navigation completes (URL + breadcrumb
+// update) but the child outlet never swaps (#189).
+//
+// Forcing the whole /inventory/create subtree to re-create whenever its active
+// child changes guarantees the outlet renders the correct child on every
+// transition — imperative links, the breadcrumb, and browser back/forward
+// alike. The previous version keyed off the *child* node, which made it a
+// no-op (it returned false only when the default strategy already did), so it
+// never actually changed the outlet behaviour.
+//
+// Everywhere else falls back to Angular's default reuse rules.
 export class NoReuseRouteStrategy extends BaseRouteReuseStrategy {
   override shouldReuseRoute(
     future: ActivatedRouteSnapshot,
     curr: ActivatedRouteSnapshot,
   ): boolean {
     if (
-      future.parent?.routeConfig?.path === 'inventory/create' &&
-      curr.parent?.routeConfig?.path === 'inventory/create' &&
-      future.routeConfig !== curr.routeConfig
+      future.routeConfig?.path === 'inventory/create' &&
+      curr.routeConfig?.path === 'inventory/create' &&
+      (future.firstChild?.routeConfig ?? null) !== (curr.firstChild?.routeConfig ?? null)
     ) {
       return false;
     }


### PR DESCRIPTION
### Ticket:

#189

### Description:

Fixes the QA send-back where, after opening a Create New Inventory form and using browser-back (or the "Create" breadcrumb) to return to `/inventory/create`, picking a different inventory type still showed the previously-opened form.

- On browser back/forward (popstate) the router-outlet under `/inventory/create` kept the previously-selected form mounted — the navigation completed (URL + breadcrumb updated) but the child outlet never swapped.
- The `NoReuseRouteStrategy` now forces the `/inventory/create` subtree to re-create whenever its active child changes, so the outlet renders the route the URL points at on every transition (links, breadcrumb, and browser back/forward).
- The previous version keyed off the *child* node, which made it a no-op (it returned `false` only when the default strategy already did), so it never changed the outlet behaviour — which is why prior attempts didn't land.

Verified locally against dev (super-admin): Create → pick a type → browser-back → pick a different type now loads the correct form.