### PR TITLE
fix(activity): restore sub-type on edit load

### DIFF
--- a/src/app/inventory/activity/activity-form/activity-form.component.ts
+++ b/src/app/inventory/activity/activity-form/activity-form.component.ts
@@ -1,4 +1,5 @@
 import {
+  AfterViewInit,
   ChangeDetectorRef,
   Component,
   OnInit,
@@ -21,7 +22,7 @@ import { CollectionSelectorComponent } from '../../../shared/components/collecti
   templateUrl: './activity-form.component.html',
   styleUrls: ['./activity-form.component.scss']
 })
-export class ActivityFormComponent implements OnInit {
+export class ActivityFormComponent implements OnInit, AfterViewInit {
   @ViewChild('searchTerms', { static: false }) searchTermsComponent!: SearchTermsComponent;
 
   @Output() formValue: EventEmitter<any> = new EventEmitter<any>();
@@ -60,6 +61,20 @@ export class ActivityFormComponent implements OnInit {
       this.cdr.detectChanges();
     });
 
+  }
+
+  ngAfterViewInit() {
+    // The ngds picklist resets its bound control during its own
+    // ngAfterViewInit if the saved value isn't in its options at that exact
+    // moment (it defers the options→value reconciliation to after view init,
+    // and an empty options array in that window wipes the value). The parent's
+    // ngAfterViewInit runs after the child's, so re-apply the saved sub-type
+    // here to restore it. See #221.
+    const savedSubType = this.activity?.activitySubType;
+    if (savedSubType && this.form.get('activitySubType')?.value !== savedSubType) {
+      this.form.get('activitySubType')?.setValue(savedSubType);
+      this.cdr.detectChanges();
+    }
   }
 
   private initializeForm() {


### PR DESCRIPTION
### Ticket:

#221

### Description:

Fixes the QA send-back where opening an activity to edit showed an empty Activity Sub Type field even though the value was saved (and visible right after saving).

- Root cause is in the ngds picklist: it defers reconciling its `selectionListItems` against the bound control to its own `ngAfterViewInit`, and **resets the control** if the value isn't in the options at that exact moment (an empty options array in that window wipes it). The earlier fix (#284, populate options before form init) didn't hold because the reset happens later, inside the picklist.
- The form's `ngAfterViewInit` runs after the picklist's, so it re-applies the saved `activitySubType` there to restore and display it.
- Guarded on the resolved activity, so it only runs in edit mode — create and activity-type-change paths are unaffected.

Verified locally against dev: editing an activity with a sub-type (e.g. Diamond Head Day-use Pass → "Trail Use") now shows the saved sub-type on load.