### PR TITLE
fix(modal): close confirmation modal on cancel

### DIFF
--- a/src/app/shared/components/confirmation-modal/confirmation-modal.component.html
+++ b/src/app/shared/components/confirmation-modal/confirmation-modal.component.html
@@ -10,6 +10,6 @@
   </div>
 </div>
 <div class="modal-footer">
-  <button type="button" class="{{ cancelClass }}" (click)="cancelButton.emit()">{{ cancelText }}</button>
+  <button type="button" class="{{ cancelClass }}" (click)="onCancel()">{{ cancelText }}</button>
   <button type="button" class="{{ confirmClass }}" (click)="confirmButton.emit()">{{ confirmText }}</button>
 </div>

--- a/src/app/shared/components/confirmation-modal/confirmation-modal.component.ts
+++ b/src/app/shared/components/confirmation-modal/confirmation-modal.component.ts
@@ -1,4 +1,5 @@
-import { Component, Input, Output, EventEmitter } from '@angular/core';
+import { Component, Input, Output, EventEmitter, Optional } from '@angular/core';
+import { BsModalRef } from 'ngx-bootstrap/modal';
 import { Utils } from '../../../utils/utils';
 import { NgFor, NgIf } from '@angular/common';
 
@@ -29,6 +30,19 @@ export class ConfirmationModalComponent {
   @Output() cancelButton = new EventEmitter<void>();
 
   public utils = new Utils();
+
+  // The modal is shown via BsModalService, so it can close itself. Optional so
+  // the component still works if ever rendered outside the modal service.
+  constructor(@Optional() private bsModalRef?: BsModalRef) {}
+
+  // Close the modal on cancel and notify any subscribers. Previously cancel only
+  // emitted the event, so callers that didn't subscribe to cancelButton (e.g.
+  // the waiting-room Mode 2 deactivate dialog) had a Cancel button that did
+  // nothing. See #262.
+  onCancel(): void {
+    this.cancelButton.emit();
+    this.bsModalRef?.hide();
+  }
 
   // This constructs the modal from the provided rows using the ModalRowSpec format.
   // It filters out rows with undefined or null values and formats them


### PR DESCRIPTION
### Ticket:

#262

### Description:

The shared confirmation modal's Cancel only emitted `cancelButton`; callers that didn't subscribe (e.g. the waiting-room Mode 2 deactivate dialog) had a Cancel that did nothing. The modal now self-dismisses on cancel (injects `BsModalRef`, Optional so it still works outside the modal service), fixing it for all callers.