### PR TITLE
fix(collection): add timezone field to create/edit forms

### DIFF
--- a/src/app/inventory/collection/collection-edit/collection-edit.component.ts
+++ b/src/app/inventory/collection/collection-edit/collection-edit.component.ts
@@ -87,6 +87,9 @@ export class CollectionEditComponent extends EntityEditBaseComponent {
     // Handle search terms
     props['searchTerms'] = this.collectionForm.get('searchTerms')?.value || [];
 
+    // Always include timezone so collections created before the field existed get backfilled
+    props['timezone'] = this.collectionForm.get('timezone')?.value;
+
     // Delete relationship form values (managed by RelationshipService post-submit)
     delete props['collectionId']; // Remove collectionId from the props
     return props;

--- a/src/app/inventory/collection/collection-form/collection-form.component.html
+++ b/src/app/inventory/collection/collection-form/collection-form.component.html
@@ -71,6 +71,19 @@
 
           <div class="row mt-4">
             <div class="col-12 col-lg-6">
+              <ngds-picklist-input class="mb-4"
+                [control]="form.get('timezone')"
+                [label]="'Timezone'"
+                [selectionListItems]="timezones"
+                [autoSelectFirstItem]="true"
+                [placeholder]="'Select timezone'"
+                [resetButton]="true">
+              </ngds-picklist-input>
+            </div>
+          </div>
+
+          <div class="row mt-4">
+            <div class="col-12 col-lg-6">
               <ngds-text-input class="mb-4"
                 [control]="form.get('adminNotes')"
                 *appPermissionRequired="'staff'"

--- a/src/app/inventory/collection/collection-form/collection-form.component.ts
+++ b/src/app/inventory/collection/collection-form/collection-form.component.ts
@@ -50,6 +50,7 @@ export class CollectionFormComponent implements OnInit {
       isVisible: [false],
       searchTerms: [[]],
       adminNotes: [''],
+      timezone: ['America/Vancouver'],
     }, {
       validators: this.isCreating ? [this.collectionIdValidator] : []
     });
@@ -64,6 +65,7 @@ export class CollectionFormComponent implements OnInit {
       isVisible: collection.isVisible ?? false,
       searchTerms: collection.searchTerms || [],
       adminNotes: collection.adminNotes || '',
+      timezone: collection.timezone || 'America/Vancouver',
     });
   }
 

--- a/src/app/inventory/create-inventory/collection-create/collection-create.component.ts
+++ b/src/app/inventory/create-inventory/collection-create/collection-create.component.ts
@@ -53,6 +53,10 @@ export class CollectionCreateComponent {
       }
       return false;
     }).filter(Boolean).reduce((acc, curr) => ({ ...acc, ...curr }), {});
+
+    // Always include timezone (the defaulted control may be pristine)
+    props['timezone'] = this.collectionForm.get('timezone')?.value;
+
     return props;
   }
 


### PR DESCRIPTION
### Ticket:

#265

### Description:

- Add timezone picklist to collection create/edit forms, defaulting to America/Vancouver
- Always submit timezone so the untouched default persists on create and older collections backfill on edit
- adminNotes fix is API-side: bcgov/reserve-rec-api#421

🤖 Generated with [Claude Code](https://claude.com/claude-code)