### PR TITLE
fix(collection): filter out non-visible collections from dropdown

### DIFF
--- a/src/app/services/collection.service.ts
+++ b/src/app/services/collection.service.ts
@@ -76,6 +76,7 @@ export class CollectionService {
       this.loadingService.addToFetchList(Constants.dataIds.COLLECTION_RESULT);
       const res = (await lastValueFrom(this.apiService.put(`collections/${collectionId}`, props)))['data'];
       this.dataService.setItemValue(Constants.dataIds.COLLECTION_RESULT, res);
+      this.dataService.clearItemValue(Constants.dataIds.COLLECTIONS_RESULT);
       this.loadingService.removeFromFetchList(Constants.dataIds.COLLECTION_RESULT);
       this.toastService.addMessage(
         `Collection successfully updated`,

--- a/src/app/shared/components/collection-selector/collection-selector.component.ts
+++ b/src/app/shared/components/collection-selector/collection-selector.component.ts
@@ -47,9 +47,11 @@ export class CollectionSelectorComponent implements OnInit {
   }
 
   setOptions(collections: any[]) {
-    this.collectionOptions = collections.map(c => ({
-      display: c.displayName ? `${c.displayName} (${c.collectionId})` : c.collectionId,
-      value: c.collectionId,
-    }));
+    this.collectionOptions = collections
+      .filter(c => c.isVisible !== false)
+      .map(c => ({
+        display: c.displayName ? `${c.displayName} (${c.collectionId})` : c.collectionId,
+        value: c.collectionId,
+      }));
   }
 }


### PR DESCRIPTION
### Ticket:
https://github.com/bcgov/reserve-rec-admin/issues/267

### Description:
- filter out non-visible collections from dropdown
- invalidate collections cache on update