### PR TITLE
Design: Delete messaging/confirmation modal component

### DIFF
--- a/src/app/inventory/activity/activity.component.ts
+++ b/src/app/inventory/activity/activity.component.ts
@@ -5,7 +5,6 @@ import { Constants } from '../../app.constants';
 import { Subscription } from 'rxjs';
 import { ConfirmationModalComponent } from '../../shared/components/confirmation-modal/confirmation-modal.component';
 import { BsModalService } from 'ngx-bootstrap/modal';
-import { ModalRowSpec } from '../../shared/components/search-terms/search-terms.component';
 import { ActivityService } from '../../services/activity.service';
 import { PermissionDirective } from '../../shared/directives/permission.directive';
 import { BreadcrumbComponent, BreadcrumbItem } from '../../shared/components/breadcrumb/breadcrumb.component';
@@ -91,18 +90,12 @@ export class ActivityComponent implements OnDestroy {
   // This sends the submitted form data object to the modal for confirmation, where
   // it constructs a confirmation modal with details and its status.
   displayConfirmationModal(collectionId, activityType, activityId) {
-    const details: ModalRowSpec[] = [
-      { label: 'Activity Name', value: this.data?.displayName },
-      { label: 'Activity Type', value: this.getActivityTypeOption()?.display },
-      { label: 'Activity Sub-Type', value: this.getActivitySubTypeOption()?.display },
-      { label: 'Activity ID', value: activityId }
-    ];
-
     // Show the modal with the confirmation details.
     const modalRef = this.modalService.show(ConfirmationModalComponent, {
+      class: 'modal-dialog-centered delete-confirmation-modal',
       initialState: {
-        title: 'Confirm Delete',
-        details,
+        title: `Delete ${this.data?.displayName}?`,
+        body: 'Deleting an inventory item will remove all associated data. Linked items will be unaffected. Are you sure you want to proceed?',
         confirmText: 'Delete',
         cancelText: 'Cancel',
         confirmClass: 'btn btn-danger',

--- a/src/app/inventory/collection/collection.component.ts
+++ b/src/app/inventory/collection/collection.component.ts
@@ -1,7 +1,6 @@
 import { CommonModule } from '@angular/common';
 import { ChangeDetectorRef, Component } from '@angular/core';
 import { ActivatedRoute, Router, RouterOutlet } from '@angular/router';
-import { ModalRowSpec } from '../../shared/components/search-terms/search-terms.component';
 import { ConfirmationModalComponent } from '../../shared/components/confirmation-modal/confirmation-modal.component';
 import { BsModalService } from 'ngx-bootstrap/modal';
 import { CollectionService } from '../../services/collection.service';
@@ -61,16 +60,12 @@ export class CollectionComponent {
   // This sends the submitted form data object to the modal for confirmation, where
   // it constructs a confirmation modal with details and its status.
   displayConfirmationModal(collectionId) {
-    const details: ModalRowSpec[] = [
-      { label: 'Collection Name', value: this.data?.displayName },
-      { label: 'Collection Collection ID', value: collectionId },
-    ];
-
     // Show the modal with the confirmation details.
     const modalRef = this.modalService.show(ConfirmationModalComponent, {
+      class: 'modal-dialog-centered delete-confirmation-modal',
       initialState: {
-        title: 'Confirm Delete',
-        details,
+        title: `Delete ${this.data?.displayName}?`,
+        body: 'Deleting an inventory item will remove all associated data. Linked items will be unaffected. Are you sure you want to proceed?',
         confirmText: 'Delete',
         cancelText: 'Cancel',
         confirmClass: 'btn btn-danger',

--- a/src/app/inventory/facility/facility.component.ts
+++ b/src/app/inventory/facility/facility.component.ts
@@ -2,7 +2,6 @@ import { CommonModule } from '@angular/common';
 import { ChangeDetectorRef, Component } from '@angular/core';
 import { ActivatedRoute, Router, RouterOutlet } from '@angular/router';
 import { Constants } from '../../app.constants';
-import { ModalRowSpec } from '../../shared/components/search-terms/search-terms.component';
 import { ConfirmationModalComponent } from '../../shared/components/confirmation-modal/confirmation-modal.component';
 import { BsModalService } from 'ngx-bootstrap/modal';
 import { FacilityService } from '../../services/facility.service';
@@ -77,18 +76,12 @@ export class FacilityComponent {
   // This sends the submitted form data object to the modal for confirmation, where
   // it constructs a confirmation modal with details and its status.
   displayConfirmationModal(collectionId, facilityType, facilityId) {
-    const details: ModalRowSpec[] = [
-      { label: 'Facility Name', value: this.data?.displayName },
-      { label: 'Facility Collection ID', value: collectionId },
-      { label: 'Facility Type', value: this.getFacilityTypeOption()?.display },
-      { label: 'Facility ID', value: facilityId }
-    ];
-
     // Show the modal with the confirmation details.
     const modalRef = this.modalService.show(ConfirmationModalComponent, {
+      class: 'modal-dialog-centered delete-confirmation-modal',
       initialState: {
-        title: 'Confirm Delete',
-        details,
+        title: `Delete ${this.data?.displayName}?`,
+        body: 'Deleting an inventory item will remove all associated data. Linked items will be unaffected. Are you sure you want to proceed?',
         confirmText: 'Delete',
         cancelText: 'Cancel',
         confirmClass: 'btn btn-danger',

--- a/src/app/inventory/geozone/geozone-details/geozone-details.component.ts
+++ b/src/app/inventory/geozone/geozone-details/geozone-details.component.ts
@@ -3,7 +3,6 @@ import { AfterViewInit, ChangeDetectorRef, Component, Input, signal, ViewChild, 
 import { MapComponent } from '../../../map/map.component';
 import { GeozoneEditComponent } from '../geozone-edit/geozone-edit.component';
 import { ActivatedRoute, Router } from '@angular/router';
-import { ModalRowSpec } from '../../../shared/components/search-terms/search-terms.component';
 import { ConfirmationModalComponent } from '../../../shared/components/confirmation-modal/confirmation-modal.component';
 import { GeozoneService } from '../../../services/geozone.service';
 import { BsModalService } from 'ngx-bootstrap/modal';
@@ -113,18 +112,15 @@ export class GeozoneDetailsComponent implements AfterViewInit {
   }
 
   async displayConfirmationModal() {
-    const details: ModalRowSpec[] = [
-      { label: 'Geozone to delete', value: this.geozone?.displayName },
-    ];
-
     // Show the modal with the confirmation details.
     const modalRef = this.modalService.show(ConfirmationModalComponent, {
+      class: 'modal-dialog-centered delete-confirmation-modal',
       initialState: {
-        title: 'Confirm Delete Geozone',
-        details,
-        confirmText: 'Confirm',
+        title: `Delete ${this.geozone?.displayName}?`,
+        body: 'Deleting an inventory item will remove all associated data. Linked items will be unaffected. Are you sure you want to proceed?',
+        confirmText: 'Delete',
         cancelText: 'Cancel',
-        confirmClass: 'btn btn-primary',
+        confirmClass: 'btn btn-danger',
         cancelClass: 'btn btn-outline-secondary'
       }
     });

--- a/src/app/inventory/geozone/geozone.component.ts
+++ b/src/app/inventory/geozone/geozone.component.ts
@@ -1,7 +1,6 @@
 import { ChangeDetectorRef, Component, signal, WritableSignal } from '@angular/core';
 import { ActivatedRoute, Router, RouterOutlet } from '@angular/router';
 import { CommonModule, UpperCasePipe } from '@angular/common';
-import { ModalRowSpec } from '../../shared/components/search-terms/search-terms.component';
 import { BsModalService } from 'ngx-bootstrap/modal';
 import { ConfirmationModalComponent } from '../../shared/components/confirmation-modal/confirmation-modal.component';
 import { GeozoneService } from '../../services/geozone.service';
@@ -64,17 +63,12 @@ export class GeozoneComponent {
   // This sends the submitted form data object to the modal for confirmation, where
   // it constructs a confirmation modal with details and its status.
   displayConfirmationModal(collectionId, geozoneId) {
-    const details: ModalRowSpec[] = [
-      { label: 'Geozone Name', value: this.data?.displayName },
-      { label: 'Geozone Collection ID', value: collectionId },
-      { label: 'Geozone ID', value: geozoneId }
-    ];
-
     // Show the modal with the confirmation details.
     const modalRef = this.modalService.show(ConfirmationModalComponent, {
+      class: 'modal-dialog-centered delete-confirmation-modal',
       initialState: {
-        title: 'Confirm Delete',
-        details,
+        title: `Delete ${this.data?.displayName}?`,
+        body: 'Deleting an inventory item will remove all associated data. Linked items will be unaffected. Are you sure you want to proceed?',
         confirmText: 'Delete',
         cancelText: 'Cancel',
         confirmClass: 'btn btn-danger',

--- a/src/app/inventory/product/product.component.ts
+++ b/src/app/inventory/product/product.component.ts
@@ -2,7 +2,6 @@ import { CommonModule } from '@angular/common';
 import { ChangeDetectorRef, Component } from '@angular/core';
 import { ActivatedRoute, Router, RouterOutlet } from '@angular/router';
 import { Constants } from '../../app.constants';
-import { ModalRowSpec } from '../../shared/components/search-terms/search-terms.component';
 import { ConfirmationModalComponent } from '../../shared/components/confirmation-modal/confirmation-modal.component';
 import { BsModalService } from 'ngx-bootstrap/modal';
 import { ProductService } from '../../services/product.service';
@@ -78,19 +77,12 @@ export class ProductComponent {
   // This sends the submitted form data object to the modal for confirmation, where
   // it constructs a confirmation modal with details and its status.
   displayConfirmationModal(collectionId, activityType, activityId, productId) {
-    const details: ModalRowSpec[] = [
-      { label: 'Product Name', value: this.data?.displayName },
-      { label: 'Product Collection ID', value: collectionId },
-      { label: 'Activity Type', value: this.getActivityTypeOption()?.display },
-      { label: 'Activity ID', value: this.data?.activityId },
-      { label: 'Product ID', value: productId }
-    ];
-
     // Show the modal with the confirmation details.
     const modalRef = this.modalService.show(ConfirmationModalComponent, {
+      class: 'modal-dialog-centered delete-confirmation-modal',
       initialState: {
-        title: 'Confirm Delete',
-        details,
+        title: `Delete ${this.data?.displayName}?`,
+        body: 'Deleting an inventory item will remove all associated data. Linked items will be unaffected. Are you sure you want to proceed?',
         confirmText: 'Delete',
         cancelText: 'Cancel',
         confirmClass: 'btn btn-danger',

--- a/src/app/shared/components/confirmation-modal/confirmation-modal.component.html
+++ b/src/app/shared/components/confirmation-modal/confirmation-modal.component.html
@@ -1,5 +1,6 @@
 <div class="modal-header">
   <h4 class="modal-title">{{ title }}</h4>
+  <button type="button" class="btn-close" aria-label="Close" (click)="cancelButton.emit()"></button>
 </div>
 <div class="modal-body">
   <p *ngIf="body">{{ body }}</p>

--- a/src/app/shared/components/confirmation-modal/confirmation-modal.component.scss
+++ b/src/app/shared/components/confirmation-modal/confirmation-modal.component.scss
@@ -1,0 +1,15 @@
+.modal-header,
+.modal-body,
+.modal-footer {
+  padding: 1.5rem;
+}
+
+.modal-title {
+  font-size: 1.25rem;
+  font-weight: 600;
+}
+
+.modal-body p {
+  font-size: 0.95rem;
+  margin-bottom: 0;
+}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -26,6 +26,12 @@ app-root {
   background-color: #fca5a5 !important;
 }
 
+// Delete confirmation modal — fixed width 634px, height hugs content (Figma)
+.delete-confirmation-modal {
+  width: 634px;
+  max-width: 634px;
+}
+
 // Workaround to make ngds-text-input label appear above the input instead of to the right
 .label-top {
   .d-flex {


### PR DESCRIPTION
### Ticket:
https://github.com/bcgov/reserve-rec-admin/issues/297
Figma design: https://www.figma.com/design/7ZxtMEp3I425MXcechDB2J/PRDT---Admin?node-id=6426-31682&m=dev

### Description:
Frontend-only change. No new components, no API or logic changes — reuses the existing shared
  ConfirmationModalComponent and the entities' existing delete flows.

  What changed:
  - confirmation-modal.component.html — added a top-right × close button (emits cancel).
  - confirmation-modal.component.scss — title/body typography + padding to match design.
  - styles.scss — .delete-confirmation-modal fixed width 634px, height hugs content.
  - 6 inventory delete call sites (collection, geozone ×2, facility, activity, product) — dynamic title Delete <name>?,
  design body copy, modal-dialog-centered delete-confirmation-modal class; removed the old detail-rows and now-unused
  ModalRowSpec import.

  Out of scope: cascading/orphan deletion of relationships is backend work — tracked in a separate ticket (exploration
  written up)
