### PR TITLE
fix: surface hidden validation errors on product create form

### DIFF
--- a/src/app/inventory/product/product-form/product-form.component.html
+++ b/src/app/inventory/product/product-form/product-form.component.html
@@ -81,8 +81,8 @@
                 [label]="'Display name'"
                 [placeholder]="'Type a display name for the product'" [resetButton]="true">
               </ngds-text-input>
-              <div 
-                *ngIf="form.hasError('invalidDisplayName') && (form.get('displayName')?.touched)"
+              <div
+                *ngIf="form.hasError('invalidDisplayName')"
                 class="alert alert-danger small p-2 mt-2"
               >
                 <strong>Invalid:</strong> please update the Display name; cannot use default value.
@@ -201,6 +201,9 @@
           <hr>
           <h3 class="mb-4 mt-4">Policies</h3>
           <p class="small mt-2">Polices are rules defining how the <strong>product</strong> behaves. They control the booking's stock, party limit, changes/cancellations, and fees. </p>
+          <div class="alert alert-warning small p-2 mb-3" *ngIf="missingRequiredPolicies().length">
+            <strong>Required:</strong> link one policy of each type — missing {{ missingRequiredPolicies().join(', ') }}.
+          </div>
           <div *ngIf="loadingPolicies" class="text-center my-3">
             <i class="fa fa-spinner fa-spin me-2"></i>
             Loading policies...

--- a/src/app/inventory/product/product-form/product-form.component.ts
+++ b/src/app/inventory/product/product-form/product-form.component.ts
@@ -369,6 +369,19 @@ export class ProductFormComponent implements OnInit {
     this.cdr.detectChanges();
   }
 
+  // List display labels for required policy types not yet linked
+  missingRequiredPolicies(): string[] {
+    const labels: Record<string, string> = {
+      reservationPolicy: 'Reservation',
+      partyPolicy: 'Party',
+      feePolicy: 'Fee',
+      changePolicy: 'Change'
+    };
+    return Object.entries(labels)
+      .filter(([controlName]) => !this.form.get(controlName)?.value)
+      .map(([, label]) => label);
+  }
+
   // Custom validator to ensure displayName is not the default placeholder
   private displayNameValidator(control: AbstractControl) {
     const group = control as UntypedFormGroup;


### PR DESCRIPTION
### Ticket:
https://github.com/bcgov/reserve-rec-admin/issues/328

### Description:
The Create Product button relied on form validity but gave no feedback when invalid. Two required fields had no visible cue:
  - displayName ships pre-filled with the literal default value ('New Product'), which its own validator rejects. The error only rendered once the field was touched, so it stayed hidden if the user never focused it.
  - reservationPolicy/partyPolicy/feePolicy/changePolicy are each required, but the Policies UI only exposes a single generic linker with no indication that all four types must be linked.

Always show the displayName error, and add a warning listing which required policy types are still unlinked.