### PR TITLE
fix(header): logout button uses absolute not fixed position so it scr…

### DIFF
--- a/src/app/shared/components/sidebar/sidebar.component.scss
+++ b/src/app/shared/components/sidebar/sidebar.component.scss
@@ -36,10 +36,11 @@ a:hover,
 }
 
 // Desktop: same button, floated back to the header's top-right corner so the
-// header looks unchanged. The sidebar list keeps its own scroll/flow.
+// header looks unchanged. Absolute (not fixed) so it scrolls away with the
+// header instead of staying pinned to the viewport.
 @media (min-width: 992px) {
   .logout-btn {
-    position: fixed;
+    position: absolute;
     top: 2rem;
     right: 1.5rem;
     z-index: 1031;


### PR DESCRIPTION
### Ticket:

https://github.com/bcgov/reserve-rec-admin/issues/327

### Description:
Issue: Logout button floats
cause:
`.logout-btn` used `position: fixed` (viewport-anchored) on desktop, so on scroll it stayed glued to screen top-right while header scrolled away — looked "floating". Changed to position: absolute (sidebar.component.scss:40-47) so it scrolls away together with header, same visual spot when unscrolled.