### PR TITLE
fix(sales): hide the pass card sub type badge when there is none (#336)

### DIFF
--- a/src/app/sales/pass-details/pass-details.component.spec.ts
+++ b/src/app/sales/pass-details/pass-details.component.spec.ts
@@ -238,6 +238,22 @@ describe('PassDetailsComponent', () => {
     expect(component.getActivitySubTypeLabel('vehicleParking')).toBe('Vehicle parking');
   });
 
+  // A booking may have no activitySubType at all (it is optional on the schema),
+  // in which case the label is empty and the badge must not render as a blank
+  // pill next to the real ones (Ref #336).
+  it('should only render the sub type badge when the booking has a sub type', () => {
+    const badgeText = () =>
+      Array.from(fixture.nativeElement.querySelectorAll('.badge-meta'))
+        .map((el: any) => el.textContent.trim());
+
+    expect(badgeText()).toEqual(['Day-use pass']);
+
+    component.booking = { ...mockBooking, activitySubType: 'vehicleParking' };
+    fixture.detectChanges();
+
+    expect(badgeText()).toEqual(['Day-use pass', 'Vehicle parking']);
+  });
+
   it('should parse epoch timestamps securely without crashing the interface', () => {
     // 1704067200000 is Jan 1, 2024
     expect(component.formatBookedDate(1704067200000)).toBe('2024-01-01');

--- a/src/app/sales/pass-details/pass-details.html
+++ b/src/app/sales/pass-details/pass-details.html
@@ -15,7 +15,8 @@
           {{ getDisplayStatus(booking) }}
         </span>
         <span class="badge rounded-pill badge-meta">{{ getActivityTypeLabel(booking.activityType) }}</span>
-        <span class="badge rounded-pill badge-meta">{{ getActivitySubTypeLabel(booking.activitySubType) }}</span>
+        <span class="badge rounded-pill badge-meta" *ngIf="booking.activitySubType">{{
+          getActivitySubTypeLabel(booking.activitySubType) }}</span>
         <span class="badge rounded-pill badge-meta" *ngIf="booking.entryPoint?.category">
           {{ booking.entryPoint.category }}
         </span>


### PR DESCRIPTION
Ticket: #336

### Description

`activitySubType` is optional on a booking, and the Sales pass card rendered its badge unconditionally — so a booking without one produced an empty pill sitting between the real badges.

- Guard the badge with `*ngIf` so it only renders when the booking has a sub type
- Cover badge rendering with and without a sub type

The reason the sub type was missing in the first place is fixed in bcgov/reserve-rec-api#456: the admin search response pruned `activitySubType` out for non-superadmins, which is every park operator. This PR only stops the empty pill; that one restores the data.

Ref #336