### PR TITLE
fix: redirect scanned QR verification URLs into Sales QR scanner

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -1,6 +1,7 @@
 import { Routes } from '@angular/router';
 import { UserGuard } from './guards/user.guard';
 import { PermissionsGuard } from './guards/permissions.guard';
+import { VerifyRedirectGuard } from './guards/verify-redirect.guard';
 import { GeozoneResolver } from './resolvers/geozone.resolver';
 import { CollectionResolver } from './resolvers/collection.resolver';
 import { FacilityResolver } from './resolvers/facility.resolver';
@@ -30,6 +31,12 @@ export const routes: Routes = [
   {
     path: 'unauthorized',
     loadComponent: () => import('./unauthorized/unauthorized.component').then(mod => mod.UnauthorizedComponent)
+  },
+  {
+    // Matches the URL encoded in a booking's QR code. Redirects into the
+    // Sales QR scanner instead of rendering directly (bcgov/reserve-rec-admin#335).
+    path: 'verify/:bookingId/:hash',
+    canActivate: [UserGuard, VerifyRedirectGuard],
   },
   {
     path: 'sales',

--- a/src/app/guards/verify-redirect.guard.ts
+++ b/src/app/guards/verify-redirect.guard.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@angular/core';
+import { ActivatedRouteSnapshot, CanActivate, Router, UrlTree } from '@angular/router';
+import { PendingScanService } from '../services/pending-scan.service';
+
+/**
+ * Catches `/verify/:bookingId/:hash` (the URL encoded in a booking's QR code)
+ * and forwards it into the Sales QR scanner page instead of rendering it directly,
+ * so a scan always lands on `/sales/qr-scanner` with the pass details shown.
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class VerifyRedirectGuard implements CanActivate {
+  constructor(private pendingScanService: PendingScanService, private router: Router) {}
+
+  canActivate(route: ActivatedRouteSnapshot): UrlTree {
+    const bookingId = route.paramMap.get('bookingId');
+    const hash = route.paramMap.get('hash');
+
+    if (bookingId && hash) {
+      this.pendingScanService.setPending({ bookingId, hash });
+    }
+
+    return this.router.parseUrl('/sales/qr-scanner');
+  }
+}

--- a/src/app/sales/qr-scanner/qr-scanner-page.component.ts
+++ b/src/app/sales/qr-scanner/qr-scanner-page.component.ts
@@ -5,6 +5,7 @@ import { lastValueFrom } from 'rxjs';
 import { ApiService } from '../../services/api.service';
 import { ToastService, ToastTypes } from '../../services/toast.service';
 import { LoggerService } from '../../services/logger.service';
+import { PendingScanService } from '../../services/pending-scan.service';
 import { QrScannerComponent, QRScanResult } from '../../shared/components/qr-scanner/qr-scanner.component';
 import { PassDetailsComponent } from '../pass-details/pass-details.component';
 
@@ -29,13 +30,21 @@ export class QrScannerPageComponent implements OnInit {
   constructor(
     private apiService: ApiService,
     private toastService: ToastService,
-    private loggerService: LoggerService
+    private loggerService: LoggerService,
+    private pendingScanService: PendingScanService
   ) {}
 
   ngOnInit(): void {
     // Check if we are in a development/sandbox environment
     const env = (window as any).__env?.ENVIRONMENT;
     this.isSandboxMode = env === 'sandbox' || env === 'local' || env === 'dev';
+
+    // If we arrived here via a scanned QR code (/verify/:bookingId/:hash),
+    // verify it immediately instead of waiting for the in-app camera scanner.
+    const pending = this.pendingScanService.takePending();
+    if (pending) {
+      this.onQRScanSuccess({ bookingId: pending.bookingId, hash: pending.hash, url: 'external-scan' });
+    }
   }
 
   private handleError(message: string, error: any) {

--- a/src/app/services/pending-scan.service.ts
+++ b/src/app/services/pending-scan.service.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@angular/core';
+
+export interface PendingScan {
+  bookingId: string;
+  hash: string;
+}
+
+/**
+ * Holds a QR scan (bookingId + hash) captured by the `/verify/:bookingId/:hash`
+ * redirect route until the Sales QR scanner page picks it up.
+ */
+@Injectable({
+  providedIn: 'root'
+})
+export class PendingScanService {
+  private pending: PendingScan | null = null;
+
+  setPending(scan: PendingScan): void {
+    this.pending = scan;
+  }
+
+  takePending(): PendingScan | null {
+    const scan = this.pending;
+    this.pending = null;
+    return scan;
+  }
+}


### PR DESCRIPTION
### Ticket:

Part of bcgov/reserve-rec-admin#335

### Description:
The QR code encodes /verify/:bookingId/:hash on the admin domain, but Admin had no route for it. Add a guard-only route that stashes the bookingId/hash and redirects into /sales/qr-scanner, which now picks up the pending scan on load and runs the same verify lookup the in-app camera scanner already used. Final URL settles on /sales/qr-scanner with pass details shown, never on /verify.
  - `src/app/services/pending-scan.service.ts` — new, holds scanned {bookingId, hash} across the redirect.
  - `src/app/guards/verify-redirect.guard.ts` — new, catches /verify/:bookingId/:hash, stores it, redirects to /sales/qr-scanner.
  - `src/app/app-routing.module.ts` — new route verify/:bookingId/:hash, guarded [UserGuard, VerifyRedirectGuard].
  - `src/app/sales/qr-scanner/qr-scanner-page.component.ts` — ngOnInit now checks PendingScanService and auto-runs the existing verify flow if a scan is pending.