### PR TITLE
fix: wire bootstrap.bundle.min.js as global script for ngds-forms 0.0.133

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -49,7 +49,7 @@
               "src/styles.scss"
             ],
             "scripts": [
-              "node_modules/@popperjs/core/dist/umd/popper.min.js",
+              "node_modules/bootstrap/dist/js/bootstrap.bundle.min.js",
               "node_modules/@digitalspace/bcparks-bootstrap-theme/dist/js/bootstrap-theme.min.js",
               "node_modules/tinymce/tinymce.min.js"
             ]

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@aws-amplify/ui": "^6.5.0",
     "@aws-amplify/ui-angular": "^5.0.24",
     "@digitalspace/bcparks-bootstrap-theme": "^1.4.6",
-    "@digitalspace/ngds-forms": "^0.0.126",
+    "@digitalspace/ngds-forms": "^0.0.133",
     "@ng-bootstrap/ng-bootstrap": "^20.0.0",
     "@popperjs/core": "^2.11.8",
     "@tinymce/tinymce-angular": "^9.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6166,10 +6166,10 @@
     bootstrap "^5.3.3"
     jquery "^3.6.0"
 
-"@digitalspace/ngds-forms@^0.0.126":
-  version "0.0.126"
-  resolved "https://registry.npmjs.org/@digitalspace/ngds-forms/-/ngds-forms-0.0.126.tgz"
-  integrity sha512-594sadKmHitVu1nBacANlXg5BgKBDdry1STviRg51ZJ7xfnoPLt8m44hIqo0DXz5OxlOxLG/l5/gmB5PowX6Xg==
+"@digitalspace/ngds-forms@^0.0.133":
+  version "0.0.133"
+  resolved "https://registry.yarnpkg.com/@digitalspace/ngds-forms/-/ngds-forms-0.0.133.tgz#e1812a5bd6c18eae495b8e22e23c3a4e88069e63"
+  integrity sha512-D580Q8sjaiB71sJ8hxf9pZciUSfDEHe/SiKv1AQ3Mseu5iXgUi7t2ECZAcbVHaYbiLfW8icHmKbV9ijBiUSxGA==
   dependencies:
     tslib "^2.3.0"
 


### PR DESCRIPTION
## Ticket
https://github.com/bcgov/reserve-rec-admin/pull/351

## Summary
- Fixes stacking of angular components
- All Collection ID / Activity / Policy typeahead and picklist dropdowns stopped populating after `@digitalspace/ngds-forms` was bumped to `0.0.133` — console showed `ReferenceError: bootstrap is not defined` and `TypeError: Cannot read properties of null (reading 'show'/'hide')`.
- `0.0.133` now calls `new bootstrap.Dropdown(...)` directly in `NgdsTypeaheadInput`/`NgdsPicklistInput`, which requires a global `window.bootstrap`. Our `bcparks-bootstrap-theme` script only exposes `window.Modal`, never `window.bootstrap`, so that dropdown instance was `null` and every subsequent `.show()`/`.hide()` call threw.
- The real `bootstrap` npm package (5.3.7) was already an installed dependency (peer dep of `ngds-forms`/`ng-bootstrap`) but never loaded as a browser global.
- Fix: swap the standalone `popper.min.js` script for `bootstrap.bundle.min.js` (bundles Popper) in `angular.json`'s `scripts` array, so `window.bootstrap` exists before `ngds-forms` initializes.
