### PR TITLE
fix: send scanning user back to their pass after login, not home

### DIFF
--- a/src/app/callback/callback.component.ts
+++ b/src/app/callback/callback.component.ts
@@ -20,7 +20,9 @@ export class CallbackComponent implements OnInit {
         console.log('Code received:', code);
         // Example: this.authService.saveCode(code);
         setTimeout(() => {
-          this.router.navigate(['/']);
+          const redirectUrl = sessionStorage.getItem('postLoginRedirectUrl');
+          sessionStorage.removeItem('postLoginRedirectUrl');
+          this.router.navigateByUrl(redirectUrl || '/');
         }, 1000); // delay for 1 second to ensure code is handled
       } else {
         // Handle the error case

--- a/src/app/guards/user.guard.ts
+++ b/src/app/guards/user.guard.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { CanActivate, Router, UrlTree } from '@angular/router';
+import { ActivatedRouteSnapshot, CanActivate, Router, RouterStateSnapshot, UrlTree } from '@angular/router';
 import { AuthService } from '../services/auth.service';
 
 @Injectable({
@@ -8,11 +8,14 @@ import { AuthService } from '../services/auth.service';
 export class UserGuard implements CanActivate {
   constructor(private authService: AuthService, private router: Router) {}
 
-  canActivate(): boolean | UrlTree {
+  canActivate(_route: ActivatedRouteSnapshot, state: RouterStateSnapshot): boolean | UrlTree {
     // Read from the cached session signal — no Cognito network call on every navigation
     if (this.authService.session()?.tokens) {
       return true;
     }
+    // Stash the intended URL so the post-login callback can return here instead
+    // of always landing on home (bcgov/reserve-rec-admin#335)
+    sessionStorage.setItem('postLoginRedirectUrl', state.url);
     return this.router.parseUrl('/login');
   }
 }


### PR DESCRIPTION
### Ticket
Part of #335 — follow-up bug reported after #348.

### What was happening
Scanning a booking's QR code while not logged in took the user to the Admin home page after signing in, instead of showing the pass they scanned.

### Why
#348 added a redirect so a scanned QR code lands on the Sales scanner page with the pass shown. But that only works if the user is already logged in. If they aren't, the login screen has no memory of what page they were trying to reach — after signing in, the app always sent them to the home page, so the scan was silently lost.

### Fix
- `user.guard.ts` now remembers the page the user was trying to reach before sending them to log in.
- `callback.component.ts` (runs right after login) now sends the user back to that page instead of always going home.

Uses `sessionStorage` rather than an in-memory value, since login is a full-page redirect out to Cognito and back — anything held only in memory would be lost.

### Verified
- Lint clean on both changed files.
- Not yet tested end-to-end in browser (needs a real QR scan + login round trip) — flagging for QA/manual check before merge.