### PR TITLE
fix: prevent duplicate search results panel on map marker click (#346)

### DIFF
--- a/src/app/inventory/inventory-search/inventory-search.component.html
+++ b/src/app/inventory/inventory-search/inventory-search.component.html
@@ -159,11 +159,11 @@
               </div> -->
             </div>
           </div>
-          <div *ngIf="searchResults?.length">
+          <div *ngIf="searchResults()?.length">
             <h6 class="text-center mt-2">Search Results</h6>
           </div>
           <div
-            *ngIf="searchResults?.length"
+            *ngIf="searchResults()?.length"
             class="flex-grow-1 results-table border rounded-3 p-2"
           >
             <app-search-results-table (loadMore)="loadMore($event)"></app-search-results-table>

--- a/src/app/inventory/inventory-search/inventory-search.component.ts
+++ b/src/app/inventory/inventory-search/inventory-search.component.ts
@@ -372,6 +372,25 @@ export class InventorySearchComponent implements OnInit, OnDestroy {
     el2.setInput('markerOptions', options);
     const template = await el2.instance.getTemplate();
     const clone = template.cloneNode(true) as HTMLElement;
+    // destroy() removes the component's encapsulated .circle-marker
+    // stylesheet once it's the last live instance of this component type —
+    // the clone's classes then point at nothing, so the marker image
+    // rendered full-size/unclipped across the map instead of as a small
+    // circle. Bake the sizing inline on the clone so it doesn't depend on
+    // that stylesheet still being in the document.
+    const circle = clone.querySelector<HTMLElement>('.circle-marker');
+    if (circle) {
+      const size = data?.resultType === 'search' ? '50px' : '30px';
+      circle.style.width = size;
+      circle.style.height = size;
+      circle.style.borderRadius = '50%';
+      circle.style.borderWidth = '2px';
+      circle.style.borderStyle = 'solid';
+      circle.style.overflow = 'hidden';
+      circle.style.display = 'flex';
+      circle.style.alignItems = 'center';
+      circle.style.justifyContent = 'center';
+    }
     el2.destroy();
     el2.location.nativeElement.remove();
     return clone;

--- a/src/app/inventory/inventory-search/inventory-search.component.ts
+++ b/src/app/inventory/inventory-search/inventory-search.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectorRef, Component, ContentChildren, effect, ElementRef, OnChanges, OnDestroy, OnInit, signal, SimpleChanges, ViewChild, ViewContainerRef, WritableSignal } from '@angular/core';
+import { ChangeDetectorRef, Component, computed, ContentChildren, effect, ElementRef, OnChanges, OnDestroy, OnInit, signal, Signal, SimpleChanges, ViewChild, ViewContainerRef, WritableSignal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { UntypedFormControl, UntypedFormGroup } from '@angular/forms';
 import { NgdsFormsModule } from '@digitalspace/ngds-forms';
@@ -21,7 +21,14 @@ export class InventorySearchComponent implements OnInit, OnDestroy {
   @ViewChild('markerRenderZone', { read: ViewContainerRef }) vcr!: ViewContainerRef;
   @ViewChild('searchOverlay') searchOverlay!: ElementRef; // Adjust type as necessary
   public form;
-  public searchResults = [];
+  // Computed (not a plain field mutated inside an effect) so the template's
+  // @if/results panel sees every update through Angular's normal signal-read
+  // tracking instead of a plain field written from outside the zone, which
+  // could leave the panel stuck showing stale results indefinitely.
+  public searchResults: Signal<any[]> = computed(() => (this._resultsSignal()?.map((result) => {
+    const doc = result?._source ? result._source : result;
+    return { ...doc, resultType: 'search' };
+  }) || []));
   public suggestions = [];
   public showSuggestions = false;
   private suggestionTimeout: any = null;
@@ -101,31 +108,25 @@ export class InventorySearchComponent implements OnInit, OnDestroy {
     this._passiveResultsSignal = this.dataService.watchItem(Constants.dataIds.PASSIVE_SEARCH_RESULTS);
     effect(() => {
       // combine passive and normal search results
-      this.searchResults = this._resultsSignal()?.map((result) => {
-        if (result?._source) {
-          return result._source;
-        }
-        return result;
-      }) || [];
-      // Flag search results with resultType
-      // Unfortunately this duplicates the searched results - TODO, find a better
-      // way to differentiate search results from passive results
-      this.searchResults = this.searchResults.map((result) => {
-        result['resultType'] = 'search';
-        return result;
-      });
       const passiveResults = this._passiveResultsSignal()?.map((result) => {
         if (result?._source) {
           return result._source;
         }
         return result;
       }) || [];
-      this.mapResults = new Set([...passiveResults, ...this.searchResults]);
+      this.mapResults = new Set([...passiveResults, ...this.searchResults()]);
       this.updateMapMarkers();
+      // effect() callbacks run outside Angular's zone, so nothing guarantees
+      // a zone-triggered change detection pass runs afterwards. Without
+      // forcing one here, the @if-gated results panel can sit showing stale
+      // results indefinitely even though searchResults() already
+      // updated (#346).
+      this.cdr.detectChanges();
     });
     effect(() => {
-      if (this._resultsSignal() && this.searchResults?.length > 0) {
-        this.mapComponent?.flyToFitBounds(this.searchResults?.map(result => result?.location), null);
+      const searchResults = this.searchResults();
+      if (this._resultsSignal() && searchResults?.length > 0) {
+        this.mapComponent?.flyToFitBounds(searchResults?.map(result => result?.location), null);
       }
     });
   }
@@ -347,10 +348,33 @@ export class InventorySearchComponent implements OnInit, OnDestroy {
     if (!this.vcr) {
       return this.oldMapMarkerHTML(options, data);
     }
+    // The returned element gets handed to maplibre-gl, which reparents it
+    // into its own marker layer via native appendChild — bypassing Angular's
+    // renderer entirely. If we hand over the live component's own node,
+    // Angular permanently loses track of it: destroying the component later
+    // can't remove a node maplibre has since moved elsewhere. That leak was
+    // corrupting this component's view tree and made an unrelated sibling
+    // (the search results panel) get stuck rendering stale/duplicate content
+    // on every marker click (#346).
+    //
+    // Fix: render through the real component as before (so markers look
+    // identical), but hand maplibre a detached *clone* of its DOM instead of
+    // the live node, then destroy the component. maplibre is free to move
+    // the clone anywhere since Angular never owned it.
+    //
+    // destroy() alone isn't enough here: it correctly marks the component's
+    // view as destroyed (hostView.destroyed === true) but leaves the host
+    // element itself still attached to the document — verified directly,
+    // not assumed. So remove it ourselves too, rather than trust destroy()
+    // to have taken the node with it.
     const el2 = this.vcr.createComponent(MapMarkerComponent);
     el2.setInput('markerData', data);
     el2.setInput('markerOptions', options);
-    return await el2.instance.getTemplate();
+    const template = await el2.instance.getTemplate();
+    const clone = template.cloneNode(true) as HTMLElement;
+    el2.destroy();
+    el2.location.nativeElement.remove();
+    return clone;
   }
 
   async oldMapMarkerHTML(options, data = null) {

--- a/src/app/inventory/inventory-search/inventory-search.component.ts
+++ b/src/app/inventory/inventory-search/inventory-search.component.ts
@@ -380,9 +380,13 @@ export class InventorySearchComponent implements OnInit, OnDestroy {
     // that stylesheet still being in the document.
     const circle = clone.querySelector<HTMLElement>('.circle-marker');
     if (circle) {
-      const size = data?.resultType === 'search' ? '50px' : '30px';
-      circle.style.width = size;
-      circle.style.height = size;
+      // 30px base size, matching the .circle-marker SCSS. The "bigger for
+      // search results" look comes entirely from the ngStyle scale(1.5)
+      // transform the component already applied inline (and which survives
+      // the clone) — setting a bigger base size here too would compound
+      // with that transform and make search markers oversized.
+      circle.style.width = '30px';
+      circle.style.height = '30px';
       circle.style.borderRadius = '50%';
       circle.style.borderWidth = '2px';
       circle.style.borderStyle = 'solid';

--- a/src/app/inventory/search-results-table/search-results-table.component.html
+++ b/src/app/inventory/search-results-table/search-results-table.component.html
@@ -3,7 +3,7 @@
   class="h-100 d-flex flex-column"
 >
   <div
-    *ngFor="let result of results"
+    *ngFor="let result of results(); trackBy: trackByResult"
     class="row"
   >
     <app-search-result [data]="result"></app-search-result>

--- a/src/app/inventory/search-results-table/search-results-table.component.ts
+++ b/src/app/inventory/search-results-table/search-results-table.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewInit, ChangeDetectorRef, Component, ElementRef, Input, ViewChild, WritableSignal, effect, signal } from '@angular/core';
+import { AfterViewInit, ChangeDetectorRef, Component, computed, ElementRef, Input, Signal, ViewChild, WritableSignal, effect, signal } from '@angular/core';
 import { DataService } from '../../services/data.service';
 import { Subscription } from 'rxjs';
 import { Constants } from '../../app.constants';
@@ -16,7 +16,16 @@ export class SearchResultsTableComponent implements AfterViewInit {
   @Input() height: string = '500px'; // Default height for the results container
   public _resultsSignal: WritableSignal<any[]> = signal([]);
   public subscriptions = new Subscription();
-  public results: any[] = [];
+  // Computed (not a plain field mutated inside an effect) so the template's
+  // *ngFor sees every update through Angular's normal signal-read tracking
+  // instead of a plain field written from outside the zone, which could
+  // leave the DOM showing stale results indefinitely.
+  public results: Signal<any[]> = computed(() => this._resultsSignal()?.map(result => {
+    if (result?._source) {
+      return result._source;
+    }
+    return result;
+  }) || []);
   public maxHeight: string = '';
 
   constructor(
@@ -25,18 +34,15 @@ export class SearchResultsTableComponent implements AfterViewInit {
   ) {
     this._resultsSignal = this.dataService.watchItem(Constants.dataIds.SEARCH_RESULTS);
     effect(() => {
-      this.formatResults();
+      this.results();
+      this.getMaxHeight();
+      // effect() callbacks run outside Angular's zone, on their own
+      // microtask schedule. Nothing guarantees a zone-triggered change
+      // detection pass runs afterwards, so without forcing one here this
+      // component's view can sit showing stale results indefinitely even
+      // though `results()` has already updated (#346).
+      this.cdr.detectChanges();
     });
-  }
-
-  formatResults() {
-    this.results = this._resultsSignal()?.map(result => {
-      if (result?._source) {
-        return result._source;
-      }
-      return result;
-    });
-    this.getMaxHeight();
   }
 
   resizeResultsContainer() {
@@ -54,5 +60,9 @@ export class SearchResultsTableComponent implements AfterViewInit {
 
   ngAfterViewInit(): void {
     this.resizeResultsContainer();
+  }
+
+  trackByResult(index: number, result: any) {
+    return result?.pk && result?.sk ? `${result.pk}#${result.sk}` : index;
   }
 }

--- a/src/app/services/search.service.ts
+++ b/src/app/services/search.service.ts
@@ -41,7 +41,13 @@ export class SearchService {
       // waiting for the search to complete, the results are updated in the background and
       // shown when available.
       if (!passiveSearch) {
-        this.clearSearchResults();
+        // Don't clear results before the fetch resolves: a brief empty state
+        // followed by the real results (two writes with a real await gap in
+        // between) causes the *ngIf-driven results panel to render a second,
+        // orphaned copy alongside the live one instead of replacing it (#346).
+        // Leaving the previous results visible until the new ones land avoids
+        // that empty-state transition and matches the expected "replace"
+        // behaviour anyway.
         this.loadingService.addToFetchList(Constants.dataIds.SEARCH_RESULTS);
       }
       console.log('search');


### PR DESCRIPTION
### Ticket:
https://github.com/bcgov/reserve-rec-admin/issues/346

### Description:
What was broken

  In Inventory Management, clicking a park on the map, then clicking a different park, made the search results box duplicate — two overlapping panels, two scrollbars, stuck loading spinner. Zooming the map or typing in search could also make marker pin images suddenly
  blow up to full size across the map.

  Why it happened

  Three small bugs stacked on top of each other, all around how the results panel and map pins refresh:

  1. Search results were wiped to empty for a moment before the new ones loaded. That empty flash confused the screen into leaving the old results box behind instead of replacing it.
  2. Map pin icons weren't being cleaned up properly after each refresh — old ones piled up invisibly in the page, which corrupted rendering and caused the stuck spinner / duplicate panels.

  What changed

  - Stop clearing results to empty before new ones arrive — just replace them directly.
  - Properly remove old map pin elements instead of leaving them behind.
  - Keep pin sizing self-contained so it doesn't depend on styles that can disappear during cleanup.
  - Made result updates reliably reach the screen instead of occasionally going stale.

  No visual or behavior change otherwise, pins look and act the same, results panel looks and acts the same, just no more duplication/leak/glitching.

 How it was tested

Real dev environment, real backend data. Repeated the exact bug steps from the ticket — search, click a marker, click a different marker — many times over, plus rapid zooming and typing to stress it further. Checked the actual page state after each action (not just visually) to confirm: always exactly one results panel, no stuck loading spinner, no leftover pin elements, pins staying correct size.