### PR TITLE
fix: Customer 'View' button showed nothing

### DIFF
--- a/src/app/customers/customer-detail/customer-detail.component.ts
+++ b/src/app/customers/customer-detail/customer-detail.component.ts
@@ -2,7 +2,6 @@ import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ActivatedRoute, Router } from '@angular/router';
 import { CustomerService } from '../../services/customer.service';
-import { LoggerService } from '../../services/logger.service';
 
 @Component({
   selector: 'app-customer-detail',
@@ -17,20 +16,12 @@ export class CustomerDetailComponent implements OnInit {
   constructor(
     private route: ActivatedRoute,
     private router: Router,
-    private customerService: CustomerService,
-    private logger: LoggerService
+    private customerService: CustomerService
   ) {}
 
   async ngOnInit() {
     this.customerId = this.route.snapshot.paramMap.get('id');
-    
-    // Get customer data from navigation state
-    const navigation = this.router.getCurrentNavigation();
-    const state = navigation?.extras?.state || (window.history.state as any);
-    
-    if (state?.customer) {
-      this.customer = state.customer;
-    }
+    this.customer = this.customerService.selectedCustomer;
   }
 
   backToCustomerList() {

--- a/src/app/customers/customers.component.html
+++ b/src/app/customers/customers.component.html
@@ -1,4 +1,4 @@
-<div class="container-fluid p-4">
+<div class="container-fluid p-4" *ngIf="!showingDetail">
   <!-- Header Section -->
   <div class="d-flex justify-content-between align-items-center mb-4">
     <h2>Customers</h2>
@@ -88,6 +88,8 @@
     </button>
   </div>
 </div>
+
+<router-outlet (activate)="showingDetail = true" (deactivate)="showingDetail = false"></router-outlet>
 
 <!-- Filter Modal -->
 <div class="modal" [class.show]="showFilterModal" [style.display]="showFilterModal ? 'block' : 'none'" tabindex="-1">

--- a/src/app/customers/customers.component.ts
+++ b/src/app/customers/customers.component.ts
@@ -1,14 +1,14 @@
 import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { Router } from '@angular/router';
+import { Router, RouterOutlet } from '@angular/router';
 import { CustomerService } from '../services/customer.service';
 import { LoggerService } from '../services/logger.service';
 import { LoadingService } from '../services/loading.service';
 
 @Component({
   selector: 'app-customers',
-  imports: [CommonModule, FormsModule],
+  imports: [CommonModule, FormsModule, RouterOutlet],
   templateUrl: './customers.component.html',
   styleUrl: './customers.component.scss'
 })
@@ -22,6 +22,7 @@ export class CustomersComponent implements OnInit {
   sortField: string = 'email';
   sortOrder: 'asc' | 'desc' = 'asc';
   showFilterModal = false;
+  showingDetail = false;
 
   // Column visibility configuration
   availableColumns = [
@@ -138,9 +139,8 @@ export class CustomersComponent implements OnInit {
 
   viewCustomer(customer: any) {
     if (customer.sub) {
-      this.router.navigate(['/customers', customer.sub], {
-        state: { customer: customer }
-      });
+      this.customerService.selectedCustomer = customer;
+      this.router.navigate(['/customers', customer.sub]);
     } else {
       this.logger.error('Customer ID (sub) not found');
     }

--- a/src/app/services/customer.service.ts
+++ b/src/app/services/customer.service.ts
@@ -14,6 +14,11 @@ interface ApiResponse {
   providedIn: 'root',
 })
 export class CustomerService {
+  // Set by the customers list right before navigating to a detail route, since
+  // router navigation `state` isn't reliably readable in a lazy-loaded
+  // (loadComponent) child's ngOnInit by the time its chunk resolves.
+  selectedCustomer: any = null;
+
   constructor(
     private apiService: ApiService,
     private logger: LoggerService


### PR DESCRIPTION
## Summary
Clicking **View** on a customer in the Customers page changed the URL but never showed the customer's details. Two bugs stacked on top of each other:

1. `customers.component.html` had no `<router-outlet>`, so the child route (`/customers/:id`) resolved successfully but had nowhere to render.
2. Once the outlet was added, the detail page still showed "Customer not found" — it was reading the selected customer only from Angular router navigation `state`, which isn't reliably readable in a lazy-loaded (`loadComponent`) route by the time its chunk finishes loading and `ngOnInit` runs.

## Fix
- Added the missing `<router-outlet>` (and `RouterOutlet` import) to `customers.component`.
- Replaced the router-state handoff with the shared `CustomerService` (a singleton): the list sets `customerService.selectedCustomer` right before navigating, and the detail component reads it in `ngOnInit`. This isn't timing-dependent.
- The list now hides while the detail view is shown (via the outlet's `(activate)`/`(deactivate)`), instead of stacking both on the page.

Related to bcgov/reserve-rec-admin#349, which also reported the View button doing nothing.

## Test plan
- [x] `ng build` succeeds
- [x] Verified in browser (localhost, dev env): clicking View on a customer row now navigates to `/customers/:id` and shows their details; list is hidden while viewing; "Back to Customer List" returns to the table.