### PR TITLE
feat(admin): optional vanity hostname + ACM cert on the admin distribution

### DIFF
--- a/lib/distribution-stack/distribution-stack.js
+++ b/lib/distribution-stack/distribution-stack.js
@@ -6,6 +6,7 @@ const iam = require('aws-cdk-lib/aws-iam');
 const { Key } = require('aws-cdk-lib/aws-kms');
 const cloudfront = require('aws-cdk-lib/aws-cloudfront');
 const origins = require('aws-cdk-lib/aws-cloudfront-origins');
+const acm = require('aws-cdk-lib/aws-certificatemanager');
 const { Duration, Fn } = require('aws-cdk-lib');
 
 const defaults = {
@@ -16,6 +17,13 @@ const defaults = {
     adminApiUrlSSMPath: '',
     kmsKeyAlias: null,
     kmsKeyRemovalPolicyDestroy: true,
+    // Optional vanity hostname. The cert must be in us-east-1 of this account and is
+    // provisioned OUT OF BAND via the ACM API (the LZA SCP denies CloudFormation in
+    // us-east-1). domainNames is comma-separated; both must be set together.
+    // Nonprod: dev-reserve-admin / test-reserve-admin (fresh names, cert already issued).
+    // Prod: reserve-admin.bcparks.ca, taken over from DUP admin at its retirement.
+    certificateArn: '',
+    domainNames: '',
   },
   constructs: {
     distBucket: {
@@ -234,6 +242,17 @@ class DistributionStack extends BaseStack {
       comment: `SPA deep-link fallback for ${this.getDeploymentName()}`,
     });
 
+    // Optional vanity hostname + cert (see defaults.config notes).
+    const domainNames = (this.getConfigValue('domainNames') || '')
+      .split(',').map((d) => d.trim()).filter((d) => d.length > 0);
+    const certificateArn = this.getConfigValue('certificateArn') || '';
+    const hasVanity = domainNames.length > 0 && certificateArn.length > 0;
+    if (hasVanity) {
+      logger.info(`Admin vanity hostnames: ${domainNames.join(', ')}`);
+    } else {
+      logger.info('No admin vanity hostname configured — serving on the *.cloudfront.net domain');
+    }
+
     // CloudFront Distribution
     this.adminDistribution = new cloudfront.Distribution(this, this.getConstructId('adminDistribution'), {
       distributionName: this.getConstructId('adminDistribution'),
@@ -294,6 +313,10 @@ class DistributionStack extends BaseStack {
       defaultRootObject: 'index.html',
       logBucket: this.logBucket,
       logIncludesCookies: false,
+      ...(hasVanity ? {
+        domainNames: domainNames,
+        certificate: acm.Certificate.fromCertificateArn(this, 'AdminCertificate', certificateArn),
+      } : {}),
     });
 
     // Export References


### PR DESCRIPTION
Admin is not path-mounted behind the front door — it keeps its own CloudFront distribution and its own hostname (bcgov/reserve-rec-api#207).

Adds optional `domainNames` + `certificateArn` config to the admin distribution stack. Empty (all envs today) = serves on `*.cloudfront.net` unchanged.

- **Nonprod (now):** `dev-reserve-admin.bcparks.ca` / `test-reserve-admin.bcparks.ca` — fresh names, nonprod cert already issued and covers them. Dev SSM config + admin Azure/Cognito callbacks already staged.
- **Prod (deferred):** `reserve-admin.bcparks.ca`, taken over from DUP admin (`EJYK43B5R2525`) at DUP admin retirement.

Cert is provisioned out of band via the ACM API (LZA SCP blocks CloudFormation in us-east-1). Parses clean.

After merge → dev deploy attaches `dev-reserve-admin.bcparks.ca`; then I create the CNAME and smoke-test.