### PR TITLE
feat(distribution): optional vanity hostname for the admin distribution (bcgov/reserve-rec-api#207)

### DIFF
--- a/lib/distribution-stack/distribution-stack.js
+++ b/lib/distribution-stack/distribution-stack.js
@@ -6,6 +6,7 @@ const iam = require('aws-cdk-lib/aws-iam');
 const { Key } = require('aws-cdk-lib/aws-kms');
 const cloudfront = require('aws-cdk-lib/aws-cloudfront');
 const origins = require('aws-cdk-lib/aws-cloudfront-origins');
+const acm = require('aws-cdk-lib/aws-certificatemanager');
 const { Duration, Fn } = require('aws-cdk-lib');
 
 const defaults = {
@@ -16,6 +17,12 @@ const defaults = {
     adminApiUrlSSMPath: '',
     kmsKeyAlias: null,
     kmsKeyRemovalPolicyDestroy: true,
+    // Vanity hostname for the admin distribution. Admin is deliberately NOT
+    // path-mounted behind the front door (reserve-rec-api#207) — it keeps its
+    // own distribution and its own hostname. Both must be set for the alias to
+    // be attached; leaving either empty keeps the plain *.cloudfront.net name.
+    certificateArn: '',
+    domainNames: '',      // comma-separated, e.g. 'dev-reserve-admin.bcparks.ca'
   },
   constructs: {
     distBucket: {
@@ -234,10 +241,25 @@ class DistributionStack extends BaseStack {
       comment: `SPA deep-link fallback for ${this.getDeploymentName()}`,
     });
 
+    // Optional vanity hostname + cert (see defaults.config notes).
+    const domainNames = (this.getConfigValue('domainNames') || '')
+      .split(',').map((d) => d.trim()).filter((d) => d.length > 0);
+    const certificateArn = this.getConfigValue('certificateArn') || '';
+    const hasVanity = domainNames.length > 0 && certificateArn.length > 0;
+    if (hasVanity) {
+      logger.info(`Admin vanity hostnames: ${domainNames.join(', ')}`);
+    } else {
+      logger.info('No vanity hostname configured — admin serves on its *.cloudfront.net domain');
+    }
+
     // CloudFront Distribution
     this.adminDistribution = new cloudfront.Distribution(this, this.getConstructId('adminDistribution'), {
       distributionName: this.getConstructId('adminDistribution'),
       enabled: true,
+      ...(hasVanity ? {
+        domainNames: domainNames,
+        certificate: acm.Certificate.fromCertificateArn(this, 'AdminDistributionCertificate', certificateArn),
+      } : {}),
       httpVersion: cloudfront.HttpVersion.HTTP2,
       defaultBehavior: {
         origin: origins.S3BucketOrigin.withOriginAccessControl(distBucketForOrigin, {
@@ -301,6 +323,14 @@ class DistributionStack extends BaseStack {
     this.exportReference(this, 'distributionId', this.adminDistribution.distributionId, `ID of the Admin CloudFront Distribution in ${this.stackId}`);
 
     this.exportReference(this, 'distributionDomainName', this.adminDistribution.domainName, `Domain name of the Admin CloudFront Distribution in ${this.stackId}`);
+
+    // The user-facing admin base: the vanity hostname when one is configured,
+    // otherwise the distribution's own domain. Kept separate from
+    // distributionDomainName so anything that needs the real *.cloudfront.net
+    // name still gets it. reserve-rec-api consumes this via its core stack's
+    // adminDomainNameSSMPath config (same seam the public side uses for
+    // publicFrontendBase — reserve-rec-api#207).
+    this.exportReference(this, 'adminFrontendBase', hasVanity ? domainNames[0] : this.adminDistribution.domainName, `Admin frontend base (host) in ${this.stackId}`);
 
   }
 }


### PR DESCRIPTION
### Description:

Admin is deliberately **not** path-mounted behind the front door — it keeps its own distribution and its own hostname. The distribution stack had no way to attach one.

- Adds `certificateArn` + `domainNames` config keys. Both must be set for the alias to attach, so any environment that doesn't configure them keeps its plain `*.cloudfront.net` name — prod synthesizes byte-identical.
- Exports `adminFrontendBase` (the vanity host when set, else the distribution domain), kept separate from `distributionDomainName` so anything needing the real CloudFront name still gets it. This mirrors the public side's `publicFrontendBase`.

Dev's `certificateArn`/`domainNames` and Azure callback URLs were already configured in SSM expecting this — the CDK support was the missing piece.

Synth-verified against test: `Aliases: ['test-reserve-admin.bcparks.ca']` with the shared multi-SAN cert; prod unchanged.

Ref bcgov/reserve-rec-api#207