### PR TITLE
fix(auth): navigate before clearing auth state on logout

### DIFF
--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -147,8 +147,7 @@ export class AuthService {
               //This is just kicking user out to login page. TODO: Add a modal to confirm logout or stay logged in?
               if (currentTime >= refreshTokenExp) {
                 this.loggerService.info('Refresh token expired. Logging out...');
-                await this.logout();
-                this.router.navigate(['/login']);
+                await this.logout('/login');
               }
             }
           }, refreshInterval);
@@ -156,8 +155,7 @@ export class AuthService {
       }
     } catch (error) {
       console.error('Error setting refresh token:', error);
-      await this.logout(); // Log out on error
-      this.router.navigate(['/login']); // Redirect to login
+      await this.logout('/login'); // Log out on error, back to login
     }
   }
 
@@ -168,13 +166,19 @@ export class AuthService {
 
 
   //Use this to ensure signal gets cleared
-  async logout() {
+  async logout(redirectTo = '/') {
     await signOut();
+    // Navigate before clearing the auth signals. The sidebar in app.component
+    // is gated on authService.user(), so clearing first tears the nav out of
+    // the layout while the previous route is still rendered in the outlet —
+    // the content jumps sideways to fill the gap before the route swaps
+    // (bcgov/reserve-rec-admin#365). Home derives its own state from Amplify's
+    // getCurrentUser(), which already reflects the signOut above, so it
+    // renders logged-out on arrival.
+    await this.router.navigate([redirectTo]);
     this.updateUser(null);
     this.session.set(null);
     this.permissionsService.clear();
-    console.log('User logged out', this.user);
-    this.router.navigate(['/']);
   }
 
   async getCurrentUser() {


### PR DESCRIPTION
### Ticket:

PRDT-

### Ticket URL:

https://github.com/bcgov/reserve-rec-admin/issues/365

### Description:

- `AuthService.logout()` cleared the auth signals before navigating. The sidebar in `app.component.html` is gated on `authService.user()`, so the nav unmounted while the previous route was still rendered in the outlet and the content column expanded to fill the gap — the redirect that would swap it wasn't awaited. Await the redirect first, then clear.
- Home derives its own state from Amplify's `getCurrentUser()` rather than these signals, and `signOut()` has already run by that point, so it renders logged-out on arrival.
- Adds a `redirectTo` param so the two session-expiry paths in `setRefresh()` go straight to `/login` instead of rendering home on the way. Also removes their second `router.navigate()`, which previously raced the one inside `logout()`.
- Drops a `console.log` that printed the user object on every logout.

Closes #365
