### PR TITLE
fix(login): remove the BCeID option

### DIFF
--- a/src/app/login/login.component.html
+++ b/src/app/login/login.component.html
@@ -22,21 +22,6 @@
           </div>
 
           <div class="login-btn-group">
-            <button class="btn btn-primary w-100" (click)="onLogin('bceid')">
-              Log in with BCeID
-            </button>
-            <p class="mb-3 text-start">
-              <a
-                href="#"
-                target="_blank"
-                rel="noopener">
-                <i class="fa-regular fa-gear"></i>
-                Register for a BCeID
-              </a>
-            </p>
-          </div>
-
-          <div class="login-btn-group">
             <button class="btn btn-primary w-100" (click)="onLogin('idir')">
               Log in with IDIR
             </button>

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -67,8 +67,10 @@ export class AuthService {
 
   loginWithProvider(provider: string) {
     let idpName = '';
+    // Only IDIR and BCSC are registered on the admin user pool client
+    // (reserve-rec-api admin-identity-stack). Naming any other provider just
+    // drops the user on Cognito's hosted chooser (bcgov/reserve-rec-admin#364).
     if (provider === 'idir') idpName = 'IDIR';
-    else if (provider === 'bceid') idpName = 'BCEID';
     else if (provider === 'bcsc') idpName = 'BCSC';
     else return;
     // Use Amplify's signInWithRedirect method to initiate the OAuth flow instead of custome method


### PR DESCRIPTION
### Ticket:

PRDT-

### Ticket URL:

https://github.com/bcgov/reserve-rec-admin/issues/364

### Description:

- The login page offered BCeID, but `BCEID` is not a registered identity provider on the admin user pool client — `reserve-rec-api` `admin-identity-stack.js` lists only the Azure OIDC provider (friendly name IDIR) and `BCSC`. Naming an unregistered provider in `signInWithRedirect` means Cognito ignores it and renders the hosted chooser, which is the IDIR/BCSC prompt in the ticket.
- Removes the BCeID button and the `loginWithProvider` branch, plus the dead `href="#"` "Register for a BCeID" placeholder link that shipped with it.
- Taking the "remove the option" path from the ticket. Actually supporting BCeID is not a frontend change: it needs a new IdP added to the API's identity stack and IDIM onboarding, which is worth its own ticket if it is wanted.

Closes #364
