### PR TITLE
fix(sales): block check-in before the pass check-in window opens

### DIFF
--- a/src/app/sales/pass-details/pass-details.component.spec.ts
+++ b/src/app/sales/pass-details/pass-details.component.spec.ts
@@ -184,7 +184,22 @@ describe('PassDetailsComponent', () => {
       reservationContext: { checkOutTime: now + 100000 }
     })).toBe(false);
 
-    // Valid scenario
+    // Cannot check in before the check-in window opens — a PM pass in the
+    // morning (#366)
+    expect(component.canCheckIn({
+      status: 'confirmed',
+      startDate: today,
+      reservationContext: { checkInTime: now + 100000, checkOutTime: now + 200000 }
+    })).toBe(false);
+
+    // Can check in once inside the window
+    expect(component.canCheckIn({
+      status: 'confirmed',
+      startDate: today,
+      reservationContext: { checkInTime: now - 100000, checkOutTime: now + 100000 }
+    })).toBe(true);
+
+    // Valid scenario — an all-day pass carries no checkInTime and is unaffected
     expect(component.canCheckIn({
       status: 'confirmed',
       startDate: today,

--- a/src/app/sales/pass-details/pass-details.component.ts
+++ b/src/app/sales/pass-details/pass-details.component.ts
@@ -115,12 +115,21 @@ export class PassDetailsComponent {
     const status = booking.status;
     const queryTime = Date.now();
     const checkedInTime = booking?.checkedInTime;
+    const checkInTime = booking.reservationContext?.checkInTime
+      ? new Date(booking.reservationContext.checkInTime).getTime()
+      : null;
     const checkOutTime = booking.reservationContext?.checkOutTime 
       ? new Date(booking.reservationContext.checkOutTime).getTime() 
       : null;
     
     // Any other status but confirmed means no check-in option
     if (status !== 'confirmed') return false;
+
+    // The check-in window has not opened yet. Without this a PM pass could be
+    // checked in during the morning (#366). The upper bound is already covered
+    // by checkOutTime below, which is what stops an AM pass being checked in
+    // after midday. Passes with no checkInTime — all-day — are unaffected.
+    if (checkInTime && queryTime < checkInTime) return false;
     
     const today = new Date().toLocaleDateString('en-CA').split('T')[0];
     const sameDay = booking.startDate == today;


### PR DESCRIPTION
### Ticket:

PRDT-

### Ticket URL:

https://github.com/bcgov/reserve-rec-admin/issues/366

### Description:

- `canCheckIn()` enforced the upper bound (`checkOutTime`) and same-day, but never the lower bound, so a PM pass was checkable from midnight. It now rejects when the booking's `checkInTime` has not been reached.
- `reservationContext.checkInTime` is the same value `getDisplayStatus()` already uses to show Reserved vs Active, so the button and the status badge now agree instead of contradicting each other.
- All-day passes carry no `checkInTime` and are unaffected, matching "all day is not applicable" from refinement.
- The "AM pass arriving after 1pm" case from refinement already worked — the existing `checkOutTime > now` check covers it. Added a regression test for the window so it stays covered.

### Verification

- New assertions in `pass-details.component.spec.ts`: rejects a pass before its window opens, accepts one inside the window, and keeps accepting an all-day pass with no `checkInTime`.
- Confirmed the test is meaningful by reverting the fix and re-running: exactly one test fails without it, 13 pass with it.
- Full suite and `ng build` clean.

### Not included

Refinement raised two things beyond the filed bug, both of which need a decision before building:

- **The 1 hour buffer outside the window.** The existing Reserved/Active/Expired colouring already gives green-inside / yellow-outside; whether the buffer is an extra grace period on top of that, and whether it should make check-in *possible* or only change the colour, is unresolved.
- **Park operator override to check in outside the window.** Refinement and davidclaveau's comment both frame this as belonging to reservations and future frontcountry offerings rather than day-use passes, and it needs a UI affordance that has not been designed. The document on bcgov/reserve-rec-public#549 also describes superadmin-configurable backdating limits, which points the same way.

This PR deliberately covers only the DUP check-in window from the ticket title. Happy to take the buffer and override work once scoped.

Closes #366
