### PR TITLE
fix(login): redirect authenticated users away from the login page

### DIFF
--- a/src/app/login/login.component.spec.ts
+++ b/src/app/login/login.component.spec.ts
@@ -1,7 +1,50 @@
-/*
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { signal } from '@angular/core';
+import { Router } from '@angular/router';
+import { LoginComponent } from './login.component';
+import { AuthService } from '../services/auth.service';
 
-*/
+describe('LoginComponent', () => {
+  let fixture: ComponentFixture<LoginComponent>;
+  let component: LoginComponent;
+  let navigatedTo: any[] | null;
+  let mockAuthService: any;
 
-xdescribe('login.component legacy placeholder', () => {
-  it('skipped', () => {});
+  async function setup(session: any) {
+    navigatedTo = null;
+    mockAuthService = {
+      session: signal(session),
+      loginWithProvider: (_p: string) => { },
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [LoginComponent],
+      providers: [
+        { provide: AuthService, useValue: mockAuthService },
+        { provide: Router, useValue: { navigate: (commands: any[]) => { navigatedTo = commands; return Promise.resolve(true); } } },
+      ],
+      schemas: [],
+    })
+      .overrideComponent(LoginComponent, { set: { template: '' } })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(LoginComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  }
+
+  it('redirects an already-authenticated user away from the login page (#360)', async () => {
+    await setup({ tokens: { idToken: 'stub' } });
+    expect(navigatedTo).toEqual(['/']);
+  });
+
+  it('leaves an unauthenticated user on the login page', async () => {
+    await setup(null);
+    expect(navigatedTo).toBeNull();
+  });
+
+  it('does not redirect when a session exists but carries no tokens', async () => {
+    await setup({});
+    expect(navigatedTo).toBeNull();
+  });
 });

--- a/src/app/login/login.component.ts
+++ b/src/app/login/login.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
 import { AuthService } from '../services/auth.service';
 
@@ -7,9 +7,20 @@ import { AuthService } from '../services/auth.service';
   templateUrl: './login.component.html',
   styleUrls: ['./login.component.scss']
 })
-export class LoginComponent {
+export class LoginComponent implements OnInit {
 
   constructor(private router: Router, private authService: AuthService) {}
+
+  ngOnInit(): void {
+    // The header renders a logged-in state app-wide, so serving the login
+    // choices to an already-authenticated user contradicts it, and the buttons
+    // kick off a pointless OAuth round-trip (#360). Send them to the dashboard
+    // instead. Reads the same session signal UserGuard trusts, which the app
+    // initializer has already populated by the time this runs.
+    if (this.authService.session()?.tokens) {
+      this.router.navigate(['/']);
+    }
+  }
 
   onLogin(provider: string) {
     this.authService.loginWithProvider(provider);


### PR DESCRIPTION
### Ticket:

PRDT-

### Ticket URL:

https://github.com/bcgov/reserve-rec-admin/issues/360

### Description:

- `LoginComponent` had no auth check, so `/login` rendered the provider buttons even when the user was already signed in — contradicting the header, which shows the logged-in state app-wide. Clicking a button then started an OAuth round-trip for an already-authenticated session.
- Takes the "redirect away from /login" option from the ticket, sending the user to `/` (the dashboard; `/dashboard` already redirects there).
- Reads `authService.session()?.tokens`, the same signal `UserGuard` uses, rather than introducing a second notion of "signed in". `authService.init()` runs through `provideAppInitializer` and awaits `setRefresh()`, so the session is populated before this route renders.
- Mirrors the equivalent fix already present in reserve-rec-public's `LoginComponent`.

### Verification

- Replaced the `xdescribe` placeholder spec with real coverage: redirects when a session carries tokens, stays put when unauthenticated, and stays put when a session object exists but has no tokens.
- Confirmed the test is meaningful by reverting the fix and re-running — one test fails without it, three pass with it.
- Full suite (30 passing) and `ng build` clean.

Closes #360
