### PR TITLE
fix(reports): drop the under construction banner

### DIFF
--- a/src/app/reports/reports.component.html
+++ b/src/app/reports/reports.component.html
@@ -6,11 +6,6 @@
     </div>
   </div>
 
-  <div class="alert alert-info border-start border-info border-4" role="alert">
-    <h4 class="alert-heading">Under construction</h4>
-    <p class="mb-0">This page is currently under construction.</p>
-  </div>
-
   <div class="row">
     <div class="col-md-4 mb-3">
       <div class="card h-100">


### PR DESCRIPTION
### Ticket:

PRDT-

### Ticket URL:

https://github.com/bcgov/reserve-rec-admin/issues/368

### Description:

- The "Under construction" notice appeared on two pages: the dashboard (`home.component.html`) and Reports (`reports.component.html`). The ticket asks for it on the dashboard only, so the Reports copy is removed and the dashboard one is untouched.
- Those were the only two occurrences in the app.
- Worth noting the Reports page already ships a working Daily Passes report, so the banner there was stale as well as unwanted.

`tsc`, full test suite and `ng build` all clean.

Closes #368
