### PR TITLE
docs(distribution): record admin vanity hostname convention (bcgov/reserve-rec-public#704)

### DIFF
--- a/lib/distribution-stack/distribution-stack.js
+++ b/lib/distribution-stack/distribution-stack.js
@@ -21,8 +21,17 @@ const defaults = {
     // path-mounted behind the front door (reserve-rec-api#207) — it keeps its
     // own distribution and its own hostname. Both must be set for the alias to
     // be attached; leaving either empty keeps the plain *.cloudfront.net name.
+    //
+    // Naming: below prod, admin nests under its environment's front-door hostname —
+    // admin.<env>-reserve.bcparks.ca. Do NOT use the <env>-reserve-admin.bcparks.ca
+    // shape: it mirrors the legacy Day Use Pass admin (reserve-admin.bcparks.ca)
+    // without inheriting anything, since DUP has no vanity hostnames below prod.
+    // Prod is the one exception — it takes the reserve-admin.bcparks.ca name over
+    // from DUP admin at retirement, for continuity (reserve-rec-api#468).
+    // The cert must live in us-east-1 of this account and is provisioned OUT OF
+    // BAND via the ACM API (the LZA SCP denies CloudFormation in us-east-1).
     certificateArn: '',
-    domainNames: '',      // comma-separated, e.g. 'dev-reserve-admin.bcparks.ca'
+    domainNames: '',      // comma-separated, e.g. 'admin.dev-reserve.bcparks.ca'
   },
   constructs: {
     distBucket: {


### PR DESCRIPTION
Ref bcgov/reserve-rec-public#704

### Description:

Records the decision on admin vanity hostnames in the `distributionStack` config, where the next person setting `domainNames` will actually read it. Comment-only — the real values live in the SSM config blob, so synth is unchanged.

- Below prod, admin nests under its environment's front door: `admin.<env>-reserve.bcparks.ca`.
- The `<env>-reserve-admin.bcparks.ca` shape is called out as off-limits. It mirrors the legacy DUP admin (`reserve-admin.bcparks.ca`) without inheriting anything from it — DUP has no vanity hostnames below prod, its nonprod frontends run on bare CloudFront domains — so it buys no continuity while reading as a sibling of the outgoing system.
- Prod is the one exception and is unchanged: `reserve-admin.bcparks.ca` is taken over from DUP admin at retirement, per bcgov/reserve-rec-api#468.

Dev/test move to the new names as a hard cutover; the old CNAMEs are deleted rather than kept as aliases.