### PR TITLE
fix(login): Update identity provider name to align with cognito idp name.

### DIFF
--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -68,7 +68,7 @@ export class AuthService {
   loginWithProvider(provider: string) {
     let idpName = '';
     if (provider === 'idir') idpName = 'IDIR';
-    else if (provider === 'bceid') idpName = 'BCEID';
+    else if (provider === 'bceid') idpName = 'BCeID';
     else if (provider === 'bcsc') idpName = 'BCSC';
     else return;
     // Use Amplify's signInWithRedirect method to initiate the OAuth flow instead of custome method


### PR DESCRIPTION
### Ticket:

PRDT-

### Ticket URL:

#

### Description:
- The idp name did not match the idp name setup in cognito for the BCeID integration (BCEID vs BCeID). Cognito/Amplify was erroring and then providing reintroducing UI to select the available identity provider options again.
- With this fix the flow moves immediately from the BCeID login button click to the BCeID login form.