### PR TITLE
revert(sales): restore morning check-in for PM passes

### DIFF
--- a/src/app/sales/pass-details/pass-details.component.spec.ts
+++ b/src/app/sales/pass-details/pass-details.component.spec.ts
@@ -184,22 +184,7 @@ describe('PassDetailsComponent', () => {
       reservationContext: { checkOutTime: now + 100000 }
     })).toBe(false);
 
-    // Cannot check in before the check-in window opens — a PM pass in the
-    // morning (#366)
-    expect(component.canCheckIn({
-      status: 'confirmed',
-      startDate: today,
-      reservationContext: { checkInTime: now + 100000, checkOutTime: now + 200000 }
-    })).toBe(false);
-
-    // Can check in once inside the window
-    expect(component.canCheckIn({
-      status: 'confirmed',
-      startDate: today,
-      reservationContext: { checkInTime: now - 100000, checkOutTime: now + 100000 }
-    })).toBe(true);
-
-    // Valid scenario — an all-day pass carries no checkInTime and is unaffected
+    // Valid scenario
     expect(component.canCheckIn({
       status: 'confirmed',
       startDate: today,

--- a/src/app/sales/pass-details/pass-details.component.ts
+++ b/src/app/sales/pass-details/pass-details.component.ts
@@ -115,21 +115,12 @@ export class PassDetailsComponent {
     const status = booking.status;
     const queryTime = Date.now();
     const checkedInTime = booking?.checkedInTime;
-    const checkInTime = booking.reservationContext?.checkInTime
-      ? new Date(booking.reservationContext.checkInTime).getTime()
-      : null;
     const checkOutTime = booking.reservationContext?.checkOutTime 
       ? new Date(booking.reservationContext.checkOutTime).getTime() 
       : null;
     
     // Any other status but confirmed means no check-in option
     if (status !== 'confirmed') return false;
-
-    // The check-in window has not opened yet. Without this a PM pass could be
-    // checked in during the morning (#366). The upper bound is already covered
-    // by checkOutTime below, which is what stops an AM pass being checked in
-    // after midday. Passes with no checkInTime — all-day — are unaffected.
-    if (checkInTime && queryTime < checkInTime) return false;
     
     const today = new Date().toLocaleDateString('en-CA').split('T')[0];
     const sameDay = booking.startDate == today;


### PR DESCRIPTION
Reverts #370. Per backlog refinement on #366 — POs keep the ability to check in a PM pass from the morning of the pass date.
