### PR TITLE
fix(home): show only the under construction banner on the dashboard (#368)

### DIFF
--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -13,52 +13,15 @@
   </div>
 </div>
 
-<div *ngIf="isAuthenticed && isAdmin" class="container d-flex flex-column align-items-center justify-content-center" style="min-height: 60vh;">
-  <div class="w-100 d-flex flex-column align-items-center">
-    <div class="container py-4">
-      <!-- Title here -->
-      <div class="row mb-4">
-        <div class="col">
-          <h1 class="display-5">Reservations System</h1>
-        </div>
-      </div>
-
-      <div class="alert alert-info border-start border-info border-4" role="alert">
-        <h4 class="alert-heading">Under construction</h4>
-        <p class="mb-0">This page is currently under construction.</p>
-      </div>
-
-      <!-- Main Content -->
-      <div class="row mb-4">
-        <div class="col-md-6">
-          <div class="mb-3 p-3 border rounded bg-light">
-            <h4>Search</h4>
-            <app-search-component></app-search-component>
-          </div>
-          <div class="p-3 border rounded bg-light">
-            <h4>Inventory Management</h4>
-            <app-inventory-component></app-inventory-component>
-          </div>
-        </div>
-        <!-- Right Column: Inventory -->
-        <div class="col-md-6">
-          <div class="h-100 p-3 border rounded bg-light">
-            <h4>Sales Management</h4>
-            <app-sales-component></app-sales-component>
-          </div>
-        </div>
-      </div>
-
-      <!-- Reports Row -->
-      <div class="row">
-        <div class="col">
-          <div class="p-3 border rounded bg-light">
-            <h4>Reports</h4>
-            <app-reports></app-reports>
-          </div>
-        </div>
-      </div>
-
+<div *ngIf="isAuthenticed && isAdmin" class="container py-4">
+  <div class="row mb-4">
+    <div class="col">
+      <h1 class="display-5">Reservations System</h1>
     </div>
+  </div>
+
+  <div class="alert alert-info border-start border-info border-4" role="alert">
+    <h4 class="alert-heading">Under construction</h4>
+    <p class="mb-0">This page is currently under construction.</p>
   </div>
 </div>

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -3,16 +3,11 @@ import { AuthService } from '../services/auth.service';
 import { Router } from '@angular/router';
 import { CommonModule } from '@angular/common';
 import { getCurrentUser } from 'aws-amplify/auth';
-import { SearchComponent } from './search/search.component';
-import { InventoryComponent } from '../inventory/inventory.component';
-import { SalesComponent } from '../sales/sales.component';
-import { ReportsComponent } from '../reports/reports.component';
 import { NgdsFormsModule } from '@digitalspace/ngds-forms';
 import { LoginComponent } from '../login/login.component';
 @Component({
   selector: 'app-home',
-  imports: [CommonModule, SearchComponent, SalesComponent, InventoryComponent, ReportsComponent, NgdsFormsModule, LoginComponent
-  ],
+  imports: [CommonModule, NgdsFormsModule, LoginComponent],
   templateUrl: './home.component.html',
 
   styleUrl: './home.component.scss'


### PR DESCRIPTION
Removes the placeholder dashboard widgets, leaving the title and the under construction banner. Matches the screenshot on #368.
