### PR TITLE
feat(customers): current and past bookings on customer detail (#118)

### DIFF
--- a/src/app/customers/customer-detail/customer-detail.component.html
+++ b/src/app/customers/customer-detail/customer-detail.component.html
@@ -81,13 +81,9 @@
           <p class="mt-2 mb-0">Loading...</p>
         </div>
 
-        <div *ngIf="!bookingsLoading && bookingsError" class="alert alert-danger mb-0">
-          {{ bookingsError }}
-        </div>
-
-        <ng-container *ngIf="!bookingsLoading && !bookingsError">
+        <ng-container *ngIf="!bookingsLoading">
           <p *ngIf="currentBookings.length === 0" class="text-muted mb-0">No current bookings</p>
-          <ng-container *ngFor="let booking of currentBookings">
+          <ng-container *ngFor="let booking of currentBookings; trackBy: trackBooking">
             <ng-container *ngTemplateOutlet="bookingCard; context: { $implicit: booking }"></ng-container>
           </ng-container>
         </ng-container>
@@ -107,20 +103,25 @@
           <p class="mt-2 mb-0">Loading...</p>
         </div>
 
-        <div *ngIf="!bookingsLoading && bookingsError" class="alert alert-danger mb-0">
-          {{ bookingsError }}
-        </div>
-
-        <ng-container *ngIf="!bookingsLoading && !bookingsError">
+        <ng-container *ngIf="!bookingsLoading">
           <p *ngIf="pastBookings.length === 0" class="text-muted mb-0">No past bookings</p>
-          <ng-container *ngFor="let booking of pastBookings">
+          <ng-container *ngFor="let booking of pastBookings; trackBy: trackBooking">
             <ng-container *ngTemplateOutlet="bookingCard; context: { $implicit: booking }"></ng-container>
           </ng-container>
         </ng-container>
       </div>
     </div>
 
-    <div *ngIf="!bookingsLoading && !bookingsError && hasMoreBookings" class="d-flex justify-content-center mb-4">
+    <!-- A failed page leaves whatever loaded on screen; this only offers the retry. -->
+    <div *ngIf="!bookingsLoading && bookingsError"
+      class="alert alert-danger d-flex flex-wrap justify-content-between align-items-center gap-2">
+      <span>{{ bookingsError }}</span>
+      <button class="btn btn-sm btn-outline-danger" (click)="retryLoadBookings()" [disabled]="bookingsLoadingMore">
+        Retry
+      </button>
+    </div>
+
+    <div *ngIf="!bookingsLoading && hasMoreBookings" class="d-flex justify-content-center mb-4">
       <div *ngIf="bookingsLoadingMore" class="spinner-border text-primary" role="status">
         <span class="visually-hidden">Loading...</span>
       </div>

--- a/src/app/customers/customer-detail/customer-detail.component.html
+++ b/src/app/customers/customer-detail/customer-detail.component.html
@@ -68,21 +68,94 @@
       </div>
     </div>
 
-    <!-- Bookings in here! -->
+    <!-- Current Bookings -->
     <div class="card shadow-sm mb-4">
       <div class="card-header bg-light">
         <h5 class="mb-0">Current Bookings</h5>
       </div>
-      <!-- Need to make logic for bookings in here-->
+      <div class="card-body">
+        <div *ngIf="bookingsLoading" class="text-center py-4">
+          <div class="spinner-border text-primary" role="status">
+            <span class="visually-hidden">Loading...</span>
+          </div>
+          <p class="mt-2 mb-0">Loading...</p>
+        </div>
+
+        <div *ngIf="!bookingsLoading && bookingsError" class="alert alert-danger mb-0">
+          {{ bookingsError }}
+        </div>
+
+        <ng-container *ngIf="!bookingsLoading && !bookingsError">
+          <p *ngIf="currentBookings.length === 0" class="text-muted mb-0">No current bookings</p>
+          <ng-container *ngFor="let booking of currentBookings">
+            <ng-container *ngTemplateOutlet="bookingCard; context: { $implicit: booking }"></ng-container>
+          </ng-container>
+        </ng-container>
+      </div>
     </div>
 
+    <!-- Past Bookings -->
     <div class="card shadow-sm mb-4">
       <div class="card-header bg-light">
         <h5 class="mb-0">Past Bookings</h5>
       </div>
-      <!-- Need to make logic for bookings in here-->
+      <div class="card-body">
+        <div *ngIf="bookingsLoading" class="text-center py-4">
+          <div class="spinner-border text-primary" role="status">
+            <span class="visually-hidden">Loading...</span>
+          </div>
+          <p class="mt-2 mb-0">Loading...</p>
+        </div>
+
+        <div *ngIf="!bookingsLoading && bookingsError" class="alert alert-danger mb-0">
+          {{ bookingsError }}
+        </div>
+
+        <ng-container *ngIf="!bookingsLoading && !bookingsError">
+          <p *ngIf="pastBookings.length === 0" class="text-muted mb-0">No past bookings</p>
+          <ng-container *ngFor="let booking of pastBookings">
+            <ng-container *ngTemplateOutlet="bookingCard; context: { $implicit: booking }"></ng-container>
+          </ng-container>
+        </ng-container>
+      </div>
+    </div>
+
+    <div *ngIf="!bookingsLoading && !bookingsError && hasMoreBookings" class="d-flex justify-content-center mb-4">
+      <div *ngIf="bookingsLoadingMore" class="spinner-border text-primary" role="status">
+        <span class="visually-hidden">Loading...</span>
+      </div>
+      <button *ngIf="!bookingsLoadingMore" class="btn btn-outline-primary" (click)="loadBookings(true)">
+        Load more
+      </button>
     </div>
   </div>
+
+  <!-- Booking summary card. Profile view only, so no check-in/check-out actions. -->
+  <ng-template #bookingCard let-booking>
+    <div class="card booking-card shadow-sm mb-3 border-0 border border-start" [ngClass]="getCardBorderClass(booking)">
+      <div class="card-body p-3 border rounded-2">
+        <div class="d-flex flex-wrap align-items-center gap-2 mb-2">
+          <h6 class="mb-0 fw-bold">{{ getBookingTitle(booking) }}</h6>
+          <span class="badge rounded-pill" [ngClass]="getStatusBgClass(booking)">
+            {{ getDisplayStatus(booking) }}
+          </span>
+        </div>
+
+        <div class="text-body small mb-1" *ngIf="getBookingLocation(booking)">
+          {{ getBookingLocation(booking) }}
+        </div>
+        <div class="text-body small mb-2" *ngIf="getPartySize(booking)">
+          Party size: {{ getPartySize(booking) }}
+        </div>
+
+        <div class="d-flex flex-column flex-lg-row flex-wrap text-body small">
+          <span class="me-1">Dates:</span><span class="me-lg-4 mb-1">{{ getBookingDates(booking) }}</span>
+          <span class="me-1">Booked:</span><span class="me-lg-4 mb-1">{{ formatBookedDate(booking.bookingCompletionTime) }}</span>
+          <span class="me-1">Confirmation ID:</span><span class="me-lg-4 mb-1">{{ booking.bookingId }}</span>
+        </div>
+      </div>
+    </div>
+  </ng-template>
 
   <!-- Error Message -->
   <div *ngIf="!customer" class="alert alert-warning">

--- a/src/app/customers/customer-detail/customer-detail.component.scss
+++ b/src/app/customers/customer-detail/customer-detail.component.scss
@@ -1,1 +1,10 @@
+// Matches the accent stripe used on the pass check-in cards.
+.booking-card {
+  border-left-width: 4px !important;
+}
 
+@media (max-width: 768px) {
+  .booking-card {
+    border-left-width: 0px !important;
+  }
+}

--- a/src/app/customers/customer-detail/customer-detail.component.spec.ts
+++ b/src/app/customers/customer-detail/customer-detail.component.spec.ts
@@ -1,29 +1,149 @@
-/*
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute, Router } from '@angular/router';
 
 import { CustomerDetailComponent } from './customer-detail.component';
+import { CustomerService } from '../../services/customer.service';
+import { LoggerService } from '../../services/logger.service';
 
 describe('CustomerDetailComponent', () => {
   let component: CustomerDetailComponent;
   let fixture: ComponentFixture<CustomerDetailComponent>;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [CustomerDetailComponent]
-    })
-    .compileComponents();
+  let mockCustomerService: any;
+  let mockLoggerService: any;
 
+  const SUB = 'cognito-sub-123';
+  const now = Date.now();
+
+  const reservedBooking = {
+    bookingId: 'r1',
+    displayName: 'Joffre Lakes, Day-use pass',
+    startDate: '2026-07-01',
+    endDate: '2026-07-01',
+    reservationContext: { checkInTime: now + 100000, checkOutTime: now + 200000 },
+  };
+  const activeBooking = {
+    bookingId: 'a1',
+    displayName: 'Garibaldi, Backcountry camping',
+    startDate: '2026-06-01',
+    endDate: '2026-06-03',
+    reservationContext: { checkOutTime: now + 100000 },
+  };
+  const expiredBooking = {
+    bookingId: 'e1',
+    displayName: 'Golden Ears, Day-use pass',
+    startDate: '2025-07-01',
+    endDate: '2025-07-01',
+    reservationContext: { checkOutTime: now - 100000 },
+  };
+  const cancelledBooking = {
+    bookingId: 'c1',
+    displayName: 'Mount Seymour, Day-use pass',
+    status: 'cancelled',
+    startDate: '2025-08-01',
+    endDate: '2025-08-01',
+  };
+
+  function setup(bookingsResponse: any = { data: { items: [], lastEvaluatedKey: null } }) {
+    mockCustomerService = {
+      selectedCustomer: { givenName: 'Jane', familyName: 'Camper', email: 'jane@example.com' },
+      getCustomerBookings: jest.fn().mockResolvedValue(bookingsResponse),
+    };
+    mockLoggerService = { error: jest.fn() };
+
+    return TestBed.configureTestingModule({
+      imports: [CustomerDetailComponent],
+      providers: [
+        { provide: CustomerService, useValue: mockCustomerService },
+        { provide: LoggerService, useValue: mockLoggerService },
+        { provide: Router, useValue: { navigate: jest.fn() } },
+        {
+          provide: ActivatedRoute,
+          useValue: { snapshot: { paramMap: { get: () => SUB } } },
+        },
+      ],
+    }).compileComponents();
+  }
+
+  async function create() {
     fixture = TestBed.createComponent(CustomerDetailComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+  }
+
+  afterEach(() => {
+    TestBed.resetTestingModule();
   });
 
-  it('should create', () => {
+  it('should create', async () => {
+    await setup();
+    await create();
     expect(component).toBeTruthy();
   });
-});
-*/
 
-xdescribe('customer-detail.component legacy placeholder', () => {
-  it('skipped', () => {});
+  it('fetches bookings for the sub in the route', async () => {
+    await setup();
+    await create();
+
+    expect(component.customerId).toBe(SUB);
+    expect(mockCustomerService.getCustomerBookings).toHaveBeenCalledWith(
+      SUB,
+      expect.objectContaining({ limit: 20 })
+    );
+  });
+
+  it('splits bookings into current and past', async () => {
+    await setup({
+      data: {
+        items: [reservedBooking, expiredBooking, activeBooking, cancelledBooking],
+        lastEvaluatedKey: null,
+      },
+    });
+    await create();
+
+    expect(component.currentBookings.map((b) => b.bookingId)).toEqual(['r1', 'a1']);
+    expect(component.pastBookings.map((b) => b.bookingId)).toEqual(['e1', 'c1']);
+    expect(component.hasMoreBookings).toBe(false);
+  });
+
+  it('renders empty states when the customer has no bookings', async () => {
+    await setup();
+    await create();
+
+    const text = fixture.nativeElement.textContent;
+    expect(text).toContain('No current bookings');
+    expect(text).toContain('No past bookings');
+  });
+
+  it('appends the next page when loading more', async () => {
+    await setup({ data: { items: [reservedBooking], lastEvaluatedKey: { pk: 'x', sk: 'y' } } });
+    await create();
+
+    expect(component.hasMoreBookings).toBe(true);
+
+    mockCustomerService.getCustomerBookings.mockResolvedValue({
+      data: { items: [expiredBooking], lastEvaluatedKey: null },
+    });
+    await component.loadBookings(true);
+
+    expect(mockCustomerService.getCustomerBookings).toHaveBeenLastCalledWith(
+      SUB,
+      expect.objectContaining({ lastEvaluatedKey: { pk: 'x', sk: 'y' } })
+    );
+    expect(component.currentBookings.map((b) => b.bookingId)).toEqual(['r1']);
+    expect(component.pastBookings.map((b) => b.bookingId)).toEqual(['e1']);
+    expect(component.hasMoreBookings).toBe(false);
+  });
+
+  it('shows an error state when the bookings request fails', async () => {
+    await setup();
+    mockCustomerService.getCustomerBookings.mockRejectedValue(new Error('boom'));
+    await create();
+
+    expect(component.bookingsError).toBeTruthy();
+    expect(mockLoggerService.error).toHaveBeenCalled();
+    expect(fixture.nativeElement.textContent).toContain('Unable to load bookings');
+  });
 });

--- a/src/app/customers/customer-detail/customer-detail.component.spec.ts
+++ b/src/app/customers/customer-detail/customer-detail.component.spec.ts
@@ -43,6 +43,14 @@ describe('CustomerDetailComponent', () => {
     startDate: '2025-08-01',
     endDate: '2025-08-01',
   };
+  const inProgressBooking = {
+    bookingId: 'p1',
+    displayName: 'Cypress, Day-use pass',
+    status: 'in progress',
+    startDate: '2026-09-01',
+    endDate: '2026-09-01',
+    reservationContext: { checkInTime: now + 100000, checkOutTime: now + 200000 },
+  };
 
   function setup(bookingsResponse: any = { data: { items: [], lastEvaluatedKey: null } }) {
     mockCustomerService = {
@@ -104,8 +112,35 @@ describe('CustomerDetailComponent', () => {
     await create();
 
     expect(component.currentBookings.map((b) => b.bookingId)).toEqual(['r1', 'a1']);
-    expect(component.pastBookings.map((b) => b.bookingId)).toEqual(['e1', 'c1']);
+    // Past is sorted newest-first by startDate: 2025-08-01 (c1) then 2025-07-01 (e1)
+    expect(component.pastBookings.map((b) => b.bookingId)).toEqual(['c1', 'e1']);
     expect(component.hasMoreBookings).toBe(false);
+  });
+
+  it('leaves an in-progress booking out of both lists', async () => {
+    await setup({
+      data: { items: [reservedBooking, inProgressBooking, expiredBooking], lastEvaluatedKey: null },
+    });
+    await create();
+
+    expect(component.currentBookings.map((b) => b.bookingId)).toEqual(['r1']);
+    expect(component.pastBookings.map((b) => b.bookingId)).toEqual(['e1']);
+  });
+
+  it('sorts past bookings newest first', async () => {
+    await setup({
+      data: {
+        items: [
+          { bookingId: 'old', status: 'cancelled', startDate: '2024-01-01' },
+          { bookingId: 'new', status: 'cancelled', startDate: '2026-01-01' },
+          { bookingId: 'mid', status: 'cancelled', startDate: '2025-01-01' },
+        ],
+        lastEvaluatedKey: null,
+      },
+    });
+    await create();
+
+    expect(component.pastBookings.map((b) => b.bookingId)).toEqual(['new', 'mid', 'old']);
   });
 
   it('renders empty states when the customer has no bookings', async () => {
@@ -145,5 +180,52 @@ describe('CustomerDetailComponent', () => {
     expect(component.bookingsError).toBeTruthy();
     expect(mockLoggerService.error).toHaveBeenCalled();
     expect(fixture.nativeElement.textContent).toContain('Unable to load bookings');
+  });
+
+  it('keeps already-loaded bookings when a further page fails', async () => {
+    await setup({ data: { items: [reservedBooking], lastEvaluatedKey: { pk: 'x', sk: 'y' } } });
+    await create();
+
+    mockCustomerService.getCustomerBookings.mockRejectedValue(new Error('boom'));
+    await component.loadBookings(true);
+    fixture.detectChanges();
+
+    expect(component.currentBookings.map((b) => b.bookingId)).toEqual(['r1']);
+    expect(component.bookingsError).toBeTruthy();
+
+    const text = fixture.nativeElement.textContent;
+    expect(text).toContain('Unable to load bookings');
+    expect(text).toContain('Joffre Lakes');
+    expect(text).not.toContain('No current bookings');
+  });
+
+  it('retries the page that failed', async () => {
+    await setup({ data: { items: [reservedBooking], lastEvaluatedKey: { pk: 'x', sk: 'y' } } });
+    await create();
+
+    mockCustomerService.getCustomerBookings.mockRejectedValue(new Error('boom'));
+    await component.loadBookings(true);
+
+    mockCustomerService.getCustomerBookings.mockResolvedValue({
+      data: { items: [expiredBooking], lastEvaluatedKey: null },
+    });
+    await component.retryLoadBookings();
+
+    expect(component.currentBookings.map((b) => b.bookingId)).toEqual(['r1']);
+    expect(component.pastBookings.map((b) => b.bookingId)).toEqual(['e1']);
+    expect(component.bookingsError).toBeNull();
+  });
+
+  it('ignores a second load while one is already in flight', async () => {
+    await setup();
+    await create();
+
+    mockCustomerService.getCustomerBookings.mockClear();
+
+    const first = component.loadBookings(true);
+    const second = component.loadBookings(true);
+    await Promise.all([first, second]);
+
+    expect(mockCustomerService.getCustomerBookings).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/app/customers/customer-detail/customer-detail.component.ts
+++ b/src/app/customers/customer-detail/customer-detail.component.ts
@@ -7,8 +7,12 @@ import {
   formatBookedDate,
   getCardBorderClass,
   getDisplayStatus,
+  getLocation,
+  getPartySize,
+  getProductDisplayName,
   getStatusBgClass,
   isCurrentBooking,
+  isPastBooking,
 } from '../../utils/booking-status';
 
 const BOOKINGS_PAGE_SIZE = 20;
@@ -30,6 +34,7 @@ export class CustomerDetailComponent implements OnInit {
   bookingsLoadingMore = false;
   bookingsError: string | null = null;
   private bookingsLastEvaluatedKey: any = null;
+  private lastLoadWasAppend = false;
 
   constructor(
     private route: ActivatedRoute,
@@ -54,18 +59,22 @@ export class CustomerDetailComponent implements OnInit {
   }
 
   async loadBookings(append = false) {
-    if (!this.customerId) return;
+    // Guard against a double-tap on "Load more" (or a reload racing the initial
+    // fetch) appending the same page twice.
+    if (!this.customerId || this.bookingsLoading || this.bookingsLoadingMore) return;
+
+    this.lastLoadWasAppend = append;
 
     try {
       if (append) {
         this.bookingsLoadingMore = true;
       } else {
         this.bookingsLoading = true;
-        this.bookingsError = null;
         this.currentBookings = [];
         this.pastBookings = [];
         this.bookingsLastEvaluatedKey = null;
       }
+      this.bookingsError = null;
 
       const res = await this.customerService.getCustomerBookings(this.customerId, {
         limit: BOOKINGS_PAGE_SIZE,
@@ -76,19 +85,44 @@ export class CustomerDetailComponent implements OnInit {
       this.bookingsLastEvaluatedKey = res?.data?.lastEvaluatedKey || null;
 
       for (const booking of items) {
+        // A booking that is neither current nor past (an abandoned "in progress"
+        // one) belongs in neither list.
         if (isCurrentBooking(booking)) {
           this.currentBookings.push(booking);
-        } else {
+        } else if (isPastBooking(booking)) {
           this.pastBookings.push(booking);
         }
       }
+
+      this.sortPastBookingsNewestFirst();
     } catch (error) {
       this.logger.error(error);
+      // A failed page must not discard what is already on screen — the sections stay
+      // rendered and the message offers a retry.
       this.bookingsError = 'Unable to load bookings for this customer.';
     } finally {
       this.bookingsLoading = false;
       this.bookingsLoadingMore = false;
     }
+  }
+
+  retryLoadBookings(): Promise<void> {
+    return this.loadBookings(this.lastLoadWasAppend);
+  }
+
+  // The API returns newest-first, but paging can interleave, so keep the finished
+  // bookings in a stable newest-first order of their own.
+  private sortPastBookingsNewestFirst() {
+    this.pastBookings.sort((a, b) => {
+      const aDate = a?.startDate || '';
+      const bDate = b?.startDate || '';
+      if (aDate === bDate) return 0;
+      return aDate < bDate ? 1 : -1;
+    });
+  }
+
+  trackBooking(index: number, booking: any): string {
+    return booking?.bookingId || booking?.sk || String(index);
   }
 
   // Booking display helpers (shared with the pass check-in cards)
@@ -110,14 +144,11 @@ export class CustomerDetailComponent implements OnInit {
   }
 
   getBookingTitle(booking: any): string {
-    const displayName = booking?.displayName || '';
-    return displayName.split(',')[0]?.trim() || booking?.activityType || 'Booking';
+    return getProductDisplayName(booking?.displayName);
   }
 
   getBookingLocation(booking: any): string {
-    const facilityName = booking?.facilityDisplayName || '';
-    const geozoneName = booking?.geozoneDisplayName || '';
-    return `${geozoneName}${facilityName ? (geozoneName ? ', ' : '') + facilityName : ''}`;
+    return getLocation(booking);
   }
 
   getBookingDates(booking: any): string {
@@ -129,13 +160,7 @@ export class CustomerDetailComponent implements OnInit {
   }
 
   getPartySize(booking: any): number {
-    if (booking?.partySize) return booking.partySize;
-    const p = booking?.partyInformation;
-    if (p) {
-      return (p.adult || 0) + (p.senior || 0) + (p.youth || 0) + (p.child || 0);
-    }
-    if (booking?.quantity) return booking.quantity;
-    return booking?.['numberOfGuests'] || 0;
+    return getPartySize(booking);
   }
 
   backToCustomerList() {

--- a/src/app/customers/customer-detail/customer-detail.component.ts
+++ b/src/app/customers/customer-detail/customer-detail.component.ts
@@ -2,6 +2,16 @@ import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ActivatedRoute, Router } from '@angular/router';
 import { CustomerService } from '../../services/customer.service';
+import { LoggerService } from '../../services/logger.service';
+import {
+  formatBookedDate,
+  getCardBorderClass,
+  getDisplayStatus,
+  getStatusBgClass,
+  isCurrentBooking,
+} from '../../utils/booking-status';
+
+const BOOKINGS_PAGE_SIZE = 20;
 
 @Component({
   selector: 'app-customer-detail',
@@ -13,15 +23,119 @@ export class CustomerDetailComponent implements OnInit {
   customer: any = null;
   customerId: string | null = null;
 
+  currentBookings: any[] = [];
+  pastBookings: any[] = [];
+
+  bookingsLoading = false;
+  bookingsLoadingMore = false;
+  bookingsError: string | null = null;
+  private bookingsLastEvaluatedKey: any = null;
+
   constructor(
     private route: ActivatedRoute,
     private router: Router,
-    private customerService: CustomerService
+    private customerService: CustomerService,
+    private logger: LoggerService
   ) {}
 
   async ngOnInit() {
+    // The route param is the customer's Cognito sub, which is also the userId
+    // every booking is stored against.
     this.customerId = this.route.snapshot.paramMap.get('id');
     this.customer = this.customerService.selectedCustomer;
+
+    if (this.customerId) {
+      await this.loadBookings();
+    }
+  }
+
+  get hasMoreBookings(): boolean {
+    return !!this.bookingsLastEvaluatedKey;
+  }
+
+  async loadBookings(append = false) {
+    if (!this.customerId) return;
+
+    try {
+      if (append) {
+        this.bookingsLoadingMore = true;
+      } else {
+        this.bookingsLoading = true;
+        this.bookingsError = null;
+        this.currentBookings = [];
+        this.pastBookings = [];
+        this.bookingsLastEvaluatedKey = null;
+      }
+
+      const res = await this.customerService.getCustomerBookings(this.customerId, {
+        limit: BOOKINGS_PAGE_SIZE,
+        lastEvaluatedKey: append ? this.bookingsLastEvaluatedKey : undefined,
+      });
+
+      const items = res?.data?.items || [];
+      this.bookingsLastEvaluatedKey = res?.data?.lastEvaluatedKey || null;
+
+      for (const booking of items) {
+        if (isCurrentBooking(booking)) {
+          this.currentBookings.push(booking);
+        } else {
+          this.pastBookings.push(booking);
+        }
+      }
+    } catch (error) {
+      this.logger.error(error);
+      this.bookingsError = 'Unable to load bookings for this customer.';
+    } finally {
+      this.bookingsLoading = false;
+      this.bookingsLoadingMore = false;
+    }
+  }
+
+  // Booking display helpers (shared with the pass check-in cards)
+
+  getDisplayStatus(booking: any): string {
+    return getDisplayStatus(booking);
+  }
+
+  getStatusBgClass(booking: any): string {
+    return getStatusBgClass(booking);
+  }
+
+  getCardBorderClass(booking: any): string {
+    return getCardBorderClass(booking);
+  }
+
+  formatBookedDate(bookingCompletionTime: number): string {
+    return formatBookedDate(bookingCompletionTime);
+  }
+
+  getBookingTitle(booking: any): string {
+    const displayName = booking?.displayName || '';
+    return displayName.split(',')[0]?.trim() || booking?.activityType || 'Booking';
+  }
+
+  getBookingLocation(booking: any): string {
+    const facilityName = booking?.facilityDisplayName || '';
+    const geozoneName = booking?.geozoneDisplayName || '';
+    return `${geozoneName}${facilityName ? (geozoneName ? ', ' : '') + facilityName : ''}`;
+  }
+
+  getBookingDates(booking: any): string {
+    const startDate = booking?.startDate;
+    const endDate = booking?.endDate;
+    if (!startDate) return '-';
+    if (!endDate || endDate === startDate) return startDate;
+    return `${startDate} to ${endDate}`;
+  }
+
+  getPartySize(booking: any): number {
+    if (booking?.partySize) return booking.partySize;
+    const p = booking?.partyInformation;
+    if (p) {
+      return (p.adult || 0) + (p.senior || 0) + (p.youth || 0) + (p.child || 0);
+    }
+    if (booking?.quantity) return booking.quantity;
+    return booking?.['numberOfGuests'] || 0;
   }
 
   backToCustomerList() {

--- a/src/app/sales/pass-details/pass-details.component.ts
+++ b/src/app/sales/pass-details/pass-details.component.ts
@@ -5,6 +5,12 @@ import { ApiService } from '../../services/api.service';
 import { ToastService, ToastTypes } from '../../services/toast.service';
 import { LoggerService } from '../../services/logger.service';
 import { lastValueFrom } from 'rxjs';
+import {
+  formatBookedDate,
+  getCardBorderClass,
+  getDisplayStatus,
+  getStatusBgClass,
+} from '../../utils/booking-status';
 
 @Component({
   selector: 'app-pass-details',
@@ -66,48 +72,17 @@ export class PassDetailsComponent {
   }
 
   getDisplayStatus(booking: any): string {
-    if (booking.status === 'cancelled') return 'Cancelled';
-
-    const now = Date.now();
-    const checkInTime = booking.reservationContext?.checkInTime 
-      ? new Date(booking.reservationContext.checkInTime).getTime() 
-      : null;
-    const checkOutTime = booking.reservationContext?.checkOutTime 
-      ? new Date(booking.reservationContext.checkOutTime).getTime() 
-      : null;
-
-    if (checkInTime && now < checkInTime) {
-      return 'Reserved';
-    }
-
-    if (checkOutTime && now > checkOutTime) {
-      return 'Expired';
-    }
-
-    return 'Active';
-  }
-
-  // Color mappings via standard Bootstrap classes.
-  // Update the class strings below if you need customized colors!
-  private readonly statusStyles = {
-    'Active': { bg: 'bg-success text-white', border: 'border-success' },
-    'Expired': { bg: 'bg-secondary text-white', border: 'border-secondary' },
-    'Cancelled': { bg: 'bg-danger text-white', border: 'border-danger' },
-    'Reserved': { bg: 'bg-warning text-dark', border: 'border-warning' }
-  };
-
-  getStatusClasses(booking: any) {
-    return this.statusStyles[this.getDisplayStatus(booking)] || this.statusStyles['Reserved'];
+    return getDisplayStatus(booking);
   }
 
   // Get the CSS class for the status badge/mobile header based on booking status
   getStatusBgClass(booking: any): string {
-    return this.getStatusClasses(booking).bg;
+    return getStatusBgClass(booking);
   }
 
   // Get the CSS class for the card border based on booking status
   getCardBorderClass(booking: any): string {
-    return this.getStatusClasses(booking).border;
+    return getCardBorderClass(booking);
   }
 
   // Check and display the check-in status of the booking
@@ -175,14 +150,7 @@ export class PassDetailsComponent {
 
   // Format the booked date to be readable in the format of "2024-01-01"
   formatBookedDate(bookingCompletionTime: number): string {
-    if (!bookingCompletionTime) return 'N/A';
-    try {
-      const date = new Date(0);
-      date.setUTCSeconds(bookingCompletionTime / 1000);
-      return date.toISOString().split('T')[0];
-    } catch {
-      return 'N/A';
-    }
+    return formatBookedDate(bookingCompletionTime);
   }
 
   // Format the check in time to be readable in the format of "3:00 PM, 2024-01-01"

--- a/src/app/sales/pass-details/pass-details.component.ts
+++ b/src/app/sales/pass-details/pass-details.component.ts
@@ -9,6 +9,9 @@ import {
   formatBookedDate,
   getCardBorderClass,
   getDisplayStatus,
+  getLocation,
+  getPartySize,
+  getProductDisplayName,
   getStatusBgClass,
 } from '../../utils/booking-status';
 
@@ -109,13 +112,7 @@ export class PassDetailsComponent {
 
   // Get the party size for a booking, calculating from party information (if available)
   getPartySize(booking: any): number {
-    if (booking.partySize) return booking.partySize;
-    const p = booking.partyInformation;
-    if (p) {
-      return (p.adult || 0) + (p.senior || 0) + (p.youth || 0) + (p.child || 0);
-    }
-    if (booking.quantity) return booking.quantity;
-    return booking['numberOfGuests'] || 0;
+    return getPartySize(booking);
   }
 
   // Get a human-readable label for the activity type (known activity types)
@@ -143,9 +140,7 @@ export class PassDetailsComponent {
 
   // Get the location string for a booking, combining facility and entry point if available
   getLocation(booking: any): string {
-    const facilityName = booking?.facilityDisplayName ? booking?.facilityDisplayName : '';
-    const geozoneName = booking?.geozoneDisplayName ? booking?.geozoneDisplayName : '';
-    return `${geozoneName}${facilityName ? ', ' + facilityName : ''}`;
+    return getLocation(booking);
   }
 
   // Format the booked date to be readable in the format of "2024-01-01"
@@ -169,8 +164,7 @@ export class PassDetailsComponent {
   }
 
   getProductDisplayName(displayName): string {
-    const parts = displayName.split(',');
-    return parts[0]?.trim() || 'N/A';
+    return getProductDisplayName(displayName);
   }
 
   private handleError(message: string, error: any) {

--- a/src/app/services/customer.service.ts
+++ b/src/app/services/customer.service.ts
@@ -50,4 +50,39 @@ export class CustomerService {
       throw error;
     }
   }
+
+  /**
+   * Fetch every booking belonging to a customer, identified by their Cognito sub.
+   * `lastEvaluatedKey` is echoed back from a previous response to fetch the next page.
+   */
+  async getCustomerBookings(
+    sub: string,
+    opts: {
+      startDate?: string;
+      endDate?: string;
+      limit?: number;
+      lastEvaluatedKey?: any;
+    } = {}
+  ) {
+    try {
+      const queryParams: any = {};
+      if (opts.startDate) queryParams.startDate = opts.startDate;
+      if (opts.endDate) queryParams.endDate = opts.endDate;
+      if (opts.limit) queryParams.limit = opts.limit;
+      if (opts.lastEvaluatedKey) {
+        queryParams.lastEvaluatedKey = JSON.stringify(opts.lastEvaluatedKey);
+      }
+
+      const res = await firstValueFrom(
+        this.apiService.get(
+          `bookings/admin/user/${encodeURIComponent(sub)}`,
+          Object.keys(queryParams).length ? queryParams : null
+        )
+      ) as ApiResponse;
+      return res;
+    } catch (error) {
+      this.logger.error(error);
+      throw error;
+    }
+  }
 }

--- a/src/app/utils/booking-status.spec.ts
+++ b/src/app/utils/booking-status.spec.ts
@@ -1,0 +1,61 @@
+import {
+  formatBookedDate,
+  getCardBorderClass,
+  getDisplayStatus,
+  getStatusBgClass,
+  isCurrentBooking,
+  isPastBooking,
+} from './booking-status';
+
+describe('booking-status utils', () => {
+  const now = Date.now();
+
+  it('derives the display status from the reservation window', () => {
+    expect(getDisplayStatus({ status: 'cancelled' })).toBe('Cancelled');
+    expect(getDisplayStatus({ reservationContext: { checkOutTime: now + 1000 } })).toBe('Active');
+    expect(getDisplayStatus({ reservationContext: { checkOutTime: now - 1000 } })).toBe('Expired');
+    expect(getDisplayStatus({
+      status: 'confirmed',
+      reservationContext: { checkInTime: now + 500, checkOutTime: now + 1000 },
+    })).toBe('Reserved');
+  });
+
+  it('treats a cancelled booking as cancelled regardless of its window', () => {
+    expect(getDisplayStatus({
+      status: 'cancelled',
+      reservationContext: { checkInTime: now + 500, checkOutTime: now + 1000 },
+    })).toBe('Cancelled');
+  });
+
+  it('maps each status onto its badge and border classes', () => {
+    const active = { reservationContext: { checkOutTime: now + 1000 } };
+    expect(getStatusBgClass(active)).toBe('bg-success text-white');
+    expect(getCardBorderClass(active)).toBe('border-success');
+
+    const cancelled = { status: 'cancelled' };
+    expect(getStatusBgClass(cancelled)).toBe('bg-danger text-white');
+    expect(getCardBorderClass(cancelled)).toBe('border-danger');
+  });
+
+  it('classifies reserved and active bookings as current, expired and cancelled as past', () => {
+    const reserved = { reservationContext: { checkInTime: now + 500, checkOutTime: now + 1000 } };
+    const active = { reservationContext: { checkOutTime: now + 1000 } };
+    const expired = { reservationContext: { checkOutTime: now - 1000 } };
+    const cancelled = { status: 'cancelled' };
+
+    expect(isCurrentBooking(reserved)).toBe(true);
+    expect(isCurrentBooking(active)).toBe(true);
+    expect(isCurrentBooking(expired)).toBe(false);
+    expect(isCurrentBooking(cancelled)).toBe(false);
+
+    expect(isPastBooking(expired)).toBe(true);
+    expect(isPastBooking(cancelled)).toBe(true);
+    expect(isPastBooking(active)).toBe(false);
+  });
+
+  it('formats the booked date and tolerates a missing timestamp', () => {
+    // 1704067200000 is Jan 1, 2024
+    expect(formatBookedDate(1704067200000)).toBe('2024-01-01');
+    expect(formatBookedDate(0)).toBe('N/A');
+  });
+});

--- a/src/app/utils/booking-status.spec.ts
+++ b/src/app/utils/booking-status.spec.ts
@@ -2,6 +2,9 @@ import {
   formatBookedDate,
   getCardBorderClass,
   getDisplayStatus,
+  getLocation,
+  getPartySize,
+  getProductDisplayName,
   getStatusBgClass,
   isCurrentBooking,
   isPastBooking,
@@ -37,6 +40,51 @@ describe('booking-status utils', () => {
     expect(getCardBorderClass(cancelled)).toBe('border-danger');
   });
 
+  it('reports an incomplete booking as In progress, in neither list', () => {
+    // 'in progress' is the status a booking carries while it is being assembled; it
+    // was never completed, so it is neither something the customer holds nor history.
+    const inProgress = {
+      status: 'in progress',
+      reservationContext: { checkInTime: now + 500, checkOutTime: now + 1000 },
+    };
+
+    expect(getDisplayStatus(inProgress)).toBe('In progress');
+    expect(isCurrentBooking(inProgress)).toBe(false);
+    expect(isPastBooking(inProgress)).toBe(false);
+  });
+
+  it('reports Unknown when the reservation window is missing or unparseable', () => {
+    expect(getDisplayStatus({ status: 'confirmed' })).toBe('Unknown');
+    expect(getDisplayStatus({ status: 'confirmed', reservationContext: {} })).toBe('Unknown');
+    expect(getDisplayStatus({
+      reservationContext: { checkInTime: null, checkOutTime: undefined },
+    })).toBe('Unknown');
+    expect(getDisplayStatus({
+      reservationContext: { checkInTime: 'not a date', checkOutTime: 'nonsense' },
+    })).toBe('Unknown');
+  });
+
+  it('classifies an Unknown booking as past with a neutral badge', () => {
+    const unknown = { status: 'confirmed' };
+
+    expect(isCurrentBooking(unknown)).toBe(false);
+    expect(isPastBooking(unknown)).toBe(true);
+    expect(getStatusBgClass(unknown)).toBe('bg-light text-dark');
+    expect(getCardBorderClass(unknown)).toBe('border-light');
+  });
+
+  it('accepts temporal anchors as numeric epochs and numeric strings', () => {
+    expect(getDisplayStatus({
+      reservationContext: { checkInTime: now + 500, checkOutTime: now + 1000 },
+    })).toBe('Reserved');
+    expect(getDisplayStatus({
+      reservationContext: { checkInTime: String(now + 500), checkOutTime: String(now + 1000) },
+    })).toBe('Reserved');
+    expect(getDisplayStatus({
+      reservationContext: { checkOutTime: String(now - 1000) },
+    })).toBe('Expired');
+  });
+
   it('classifies reserved and active bookings as current, expired and cancelled as past', () => {
     const reserved = { reservationContext: { checkInTime: now + 500, checkOutTime: now + 1000 } };
     const active = { reservationContext: { checkOutTime: now + 1000 } };
@@ -51,6 +99,31 @@ describe('booking-status utils', () => {
     expect(isPastBooking(expired)).toBe(true);
     expect(isPastBooking(cancelled)).toBe(true);
     expect(isPastBooking(active)).toBe(false);
+  });
+
+  it('reads party size from partyContext, falling back to quantity', () => {
+    expect(getPartySize({ partyContext: { adult: 2, senior: 1, youth: 1, child: 1 } })).toBe(5);
+    // OpenSearch documents carry the same breakdown under partyInformation
+    expect(getPartySize({ partyInformation: { adult: 2, child: 1 } })).toBe(3);
+    expect(getPartySize({ partySize: 4 })).toBe(4);
+    expect(getPartySize({ quantity: 4 })).toBe(4);
+    // An empty breakdown must not shadow the quantity fallback
+    expect(getPartySize({ partyContext: {}, quantity: 2 })).toBe(2);
+    expect(getPartySize({})).toBe(0);
+  });
+
+  it('joins location parts without a leading separator', () => {
+    expect(getLocation({ geozoneDisplayName: 'Garibaldi', facilityDisplayName: 'Elfin Lakes' }))
+      .toBe('Garibaldi, Elfin Lakes');
+    expect(getLocation({ geozoneDisplayName: 'Garibaldi' })).toBe('Garibaldi');
+    expect(getLocation({ facilityDisplayName: 'Elfin Lakes' })).toBe('Elfin Lakes');
+    expect(getLocation({})).toBe('');
+  });
+
+  it('takes the product name off the front of the display name', () => {
+    expect(getProductDisplayName('Joffre Lakes, 2026-07-01')).toBe('Joffre Lakes');
+    expect(getProductDisplayName('Joffre Lakes')).toBe('Joffre Lakes');
+    expect(getProductDisplayName(undefined)).toBe('N/A');
   });
 
   it('formats the booked date and tolerates a missing timestamp', () => {

--- a/src/app/utils/booking-status.ts
+++ b/src/app/utils/booking-status.ts
@@ -1,13 +1,19 @@
 /**
  * Shared booking display helpers.
  *
- * A booking's stored `status` only tells us whether it was cancelled — whether it
- * is upcoming, in progress or over is derived from the reservation window. These
- * helpers are used by both the pass check-in cards and the customer detail view so
- * the two never drift apart.
+ * A booking's stored `status` only tells us whether it was cancelled or still being
+ * assembled — whether it is upcoming, in progress or over is derived from the
+ * reservation window. These helpers are used by both the pass check-in cards and the
+ * customer detail view so the two never drift apart.
  */
 
-export type BookingDisplayStatus = 'Reserved' | 'Active' | 'Expired' | 'Cancelled';
+export type BookingDisplayStatus =
+  | 'Reserved'
+  | 'Active'
+  | 'Expired'
+  | 'Cancelled'
+  | 'In progress'
+  | 'Unknown';
 
 // Color mappings via standard Bootstrap classes.
 // Update the class strings below if you need customized colors!
@@ -15,28 +21,58 @@ const STATUS_STYLES: Record<BookingDisplayStatus, { bg: string; border: string }
   'Active': { bg: 'bg-success text-white', border: 'border-success' },
   'Expired': { bg: 'bg-secondary text-white', border: 'border-secondary' },
   'Cancelled': { bg: 'bg-danger text-white', border: 'border-danger' },
-  'Reserved': { bg: 'bg-warning text-dark', border: 'border-warning' }
+  'Reserved': { bg: 'bg-warning text-dark', border: 'border-warning' },
+  'In progress': { bg: 'bg-info text-dark', border: 'border-info' },
+  'Unknown': { bg: 'bg-light text-dark', border: 'border-light' }
 };
 
-// Bookings the customer can still use, versus ones that are done with.
+// Bookings the customer can still turn up and use.
 const CURRENT_STATUSES: BookingDisplayStatus[] = ['Reserved', 'Active'];
+
+// Bookings that are over, one way or another. 'In progress' is in neither list: the
+// booking was never completed, so it is not something the customer holds, but it is
+// also not part of their history.
+const PAST_STATUSES: BookingDisplayStatus[] = ['Expired', 'Cancelled', 'Unknown'];
+
+/**
+ * Coerce a stored temporal anchor to epoch ms. Anchors are written as ISO strings but
+ * have also been seen as numeric epochs and numeric strings, and may be absent.
+ */
+function toEpoch(value: any): number | null {
+  if (value === null || value === undefined || value === '') return null;
+
+  if (typeof value === 'number') {
+    return isNaN(value) ? null : value;
+  }
+
+  if (typeof value === 'string' && /^\d+$/.test(value.trim())) {
+    const numeric = Number(value.trim());
+    return isNaN(numeric) ? null : numeric;
+  }
+
+  const parsed = new Date(value).getTime();
+  return isNaN(parsed) ? null : parsed;
+}
 
 export function getDisplayStatus(booking: any): BookingDisplayStatus {
   if (booking?.status === 'cancelled') return 'Cancelled';
+  if (booking?.status === 'in progress') return 'In progress';
 
   const now = Date.now();
-  const checkInTime = booking?.reservationContext?.checkInTime
-    ? new Date(booking.reservationContext.checkInTime).getTime()
-    : null;
-  const checkOutTime = booking?.reservationContext?.checkOutTime
-    ? new Date(booking.reservationContext.checkOutTime).getTime()
-    : null;
+  const checkInTime = toEpoch(booking?.reservationContext?.checkInTime);
+  const checkOutTime = toEpoch(booking?.reservationContext?.checkOutTime);
 
-  if (checkInTime && now < checkInTime) {
+  // Without a usable window there is nothing to derive a status from — say so rather
+  // than defaulting to 'Active' and telling staff a stale booking is still usable.
+  if (checkInTime === null && checkOutTime === null) {
+    return 'Unknown';
+  }
+
+  if (checkInTime !== null && now < checkInTime) {
     return 'Reserved';
   }
 
-  if (checkOutTime && now > checkOutTime) {
+  if (checkOutTime !== null && now > checkOutTime) {
     return 'Expired';
   }
 
@@ -44,7 +80,7 @@ export function getDisplayStatus(booking: any): BookingDisplayStatus {
 }
 
 export function getStatusClasses(booking: any): { bg: string; border: string } {
-  return STATUS_STYLES[getDisplayStatus(booking)] || STATUS_STYLES['Reserved'];
+  return STATUS_STYLES[getDisplayStatus(booking)] || STATUS_STYLES['Unknown'];
 }
 
 // Get the CSS class for the status badge/mobile header based on booking status
@@ -62,7 +98,40 @@ export function isCurrentBooking(booking: any): boolean {
 }
 
 export function isPastBooking(booking: any): boolean {
-  return !isCurrentBooking(booking);
+  return PAST_STATUSES.includes(getDisplayStatus(booking));
+}
+
+// Get the party size for a booking. The API stores the demographic breakdown as
+// partyContext (partyInformation on the OpenSearch documents); quantity is the
+// last-resort fallback for records that never carried a breakdown.
+export function getPartySize(booking: any): number {
+  if (booking?.partySize) return booking.partySize;
+
+  const party = booking?.partyContext || booking?.partyInformation;
+  if (party) {
+    const total =
+      (party.adult || 0) +
+      (party.senior || 0) +
+      (party.youth || 0) +
+      (party.child || 0);
+    if (total) return total;
+  }
+
+  if (booking?.quantity) return booking.quantity;
+  return booking?.['numberOfGuests'] || 0;
+}
+
+// Get the location string for a booking, combining geozone and facility if available
+export function getLocation(booking: any): string {
+  const facilityName = booking?.facilityDisplayName || '';
+  const geozoneName = booking?.geozoneDisplayName || '';
+  return [geozoneName, facilityName].filter(Boolean).join(', ');
+}
+
+// displayName is stored as "Product name, <dates>" — take the product name only
+export function getProductDisplayName(displayName: any): string {
+  if (!displayName) return 'N/A';
+  return String(displayName).split(',')[0]?.trim() || 'N/A';
 }
 
 // Format the booked date to be readable in the format of "2024-01-01"

--- a/src/app/utils/booking-status.ts
+++ b/src/app/utils/booking-status.ts
@@ -1,0 +1,78 @@
+/**
+ * Shared booking display helpers.
+ *
+ * A booking's stored `status` only tells us whether it was cancelled — whether it
+ * is upcoming, in progress or over is derived from the reservation window. These
+ * helpers are used by both the pass check-in cards and the customer detail view so
+ * the two never drift apart.
+ */
+
+export type BookingDisplayStatus = 'Reserved' | 'Active' | 'Expired' | 'Cancelled';
+
+// Color mappings via standard Bootstrap classes.
+// Update the class strings below if you need customized colors!
+const STATUS_STYLES: Record<BookingDisplayStatus, { bg: string; border: string }> = {
+  'Active': { bg: 'bg-success text-white', border: 'border-success' },
+  'Expired': { bg: 'bg-secondary text-white', border: 'border-secondary' },
+  'Cancelled': { bg: 'bg-danger text-white', border: 'border-danger' },
+  'Reserved': { bg: 'bg-warning text-dark', border: 'border-warning' }
+};
+
+// Bookings the customer can still use, versus ones that are done with.
+const CURRENT_STATUSES: BookingDisplayStatus[] = ['Reserved', 'Active'];
+
+export function getDisplayStatus(booking: any): BookingDisplayStatus {
+  if (booking?.status === 'cancelled') return 'Cancelled';
+
+  const now = Date.now();
+  const checkInTime = booking?.reservationContext?.checkInTime
+    ? new Date(booking.reservationContext.checkInTime).getTime()
+    : null;
+  const checkOutTime = booking?.reservationContext?.checkOutTime
+    ? new Date(booking.reservationContext.checkOutTime).getTime()
+    : null;
+
+  if (checkInTime && now < checkInTime) {
+    return 'Reserved';
+  }
+
+  if (checkOutTime && now > checkOutTime) {
+    return 'Expired';
+  }
+
+  return 'Active';
+}
+
+export function getStatusClasses(booking: any): { bg: string; border: string } {
+  return STATUS_STYLES[getDisplayStatus(booking)] || STATUS_STYLES['Reserved'];
+}
+
+// Get the CSS class for the status badge/mobile header based on booking status
+export function getStatusBgClass(booking: any): string {
+  return getStatusClasses(booking).bg;
+}
+
+// Get the CSS class for the card border based on booking status
+export function getCardBorderClass(booking: any): string {
+  return getStatusClasses(booking).border;
+}
+
+export function isCurrentBooking(booking: any): boolean {
+  return CURRENT_STATUSES.includes(getDisplayStatus(booking));
+}
+
+export function isPastBooking(booking: any): boolean {
+  return !isCurrentBooking(booking);
+}
+
+// Format the booked date to be readable in the format of "2024-01-01"
+export function formatBookedDate(bookingCompletionTime: number): string {
+  if (!bookingCompletionTime) return 'N/A';
+  try {
+    const date = new Date(0);
+    date.setUTCSeconds(bookingCompletionTime / 1000);
+    return date.toISOString().split('T')[0];
+  } catch {
+    return 'N/A';
+  }
+}


### PR DESCRIPTION
### Ticket: [118](https://github.com/bcgov/reserve-rec-admin/issues/118)

### Description:
- Fills the stubbed Current/Past Bookings cards on the customer detail view. Bookings are fetched by the customer's Cognito sub from a new staff-tier admin endpoint (bcgov/reserve-rec-api#488 — merge that first), newest first, with load-more pagination.
- Classification: Current = Reserved or Active, Past = Expired or Cancelled, derived from status + check-in/check-out windows. `in progress` (abandoned carts) is excluded from both lists; bookings with no usable time anchors show as Unknown and sort into Past.
- The status/badge/location/party-size helpers are extracted from PassDetailsComponent into a shared `booking-status` util used by both views. One deliberate behaviour change: with an empty geozone the location renders "Facility" instead of ", Facility".
- A failed load-more keeps already-rendered bookings and offers Retry.
- The ticket's dev checklist said "use search endpoint"; the implementation queries the userId GSI directly instead — `/bookings/search` has no userId filter and OpenSearch indexing lag would show stale history. Flagging as a deliberate deviation.

Decisions for PO/review:
- Cross-collection scope: any user with `staff` in at least one collection can view a customer's bookings across all parks. Collection-scoping a profile view is ambiguous (customers book across parks) — confirm this is acceptable or specify the scoping rule.
- Release step: verified against live DynamoDB (dev/test/prod) — no resourceMap change needed; `resourceMap::staff` already carries `GET/bookings*`, which covers the new route. `resourceMap::limited` carries it too, so the endpoint's in-handler staff check is what keeps Park Operators out (tested).

Ref #118
